### PR TITLE
fix: URL length for mainnet

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,8 +21,13 @@ export default {
   ): Promise<Response> {
     const networks = env.SUPPORTED_NETWORKS;
     const url = new URL(request.url);
-    const network = url.pathname.split("/")[1];
-    const name = url.pathname.split("/")[2];
+    let network = url.pathname.split("/")[1];
+    let name = url.pathname.split("/")[2];
+
+    if (!name) {
+      name = network;
+      network = "mainnet";
+    }
 
     if (!network || !networks.includes(network)) {
       return makeResponse("Network not supported", 400);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -11,26 +11,18 @@ const mf = new Miniflare({
 });
 
 describe("index", () => {
-  it("should throw error if no network supplied", async () => {
-    const response = await mf.dispatchFetch("http://localhost/");
-    const { message } = await response.json<ResObj>();
-
-    expect(message).toBe("Network not supported");
-    expect(response.status).toBe(400);
-  });
-  it("should throw error if network not supported", async () => {
-    const response = await mf.dispatchFetch("http://localhost/test");
-    const { message } = await response.json<ResObj>();
-
-    expect(message).toBe("Network not supported");
-    expect(response.status).toBe(400);
-  });
   it("should throw error if no name supplied", async () => {
-    const response = await mf.dispatchFetch("http://localhost/mainnet");
+    const response = await mf.dispatchFetch("http://localhost/");
     const { message } = await response.json<ResObj>();
 
     expect(message).toBe("Missing name parameter");
     expect(response.status).toBe(400);
+  });
+  it("should assume network is mainnet if no second path", async () => {
+    const response = await mf.dispatchFetch("http://localhost/test");
+
+    const { message } = await response.json<ResObj>();
+    expect(message).toBe("get");
   });
   it("should use put handler for put request", async () => {
     const response = await mf.dispatchFetch("http://localhost/mainnet/test", {


### PR DESCRIPTION
removed requirement for network path item if network is mainnet
(assumes mainnet is network if only 1 path item)