### PR TITLE
feat: sca sig support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,5 +17,8 @@ jobs:
           node-version: 18
           cache: "pnpm"
 
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
       - run: pnpm install --frozen-lockfile
       - run: pnpm test

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20231218.0",
+    "@viem/anvil": "^0.0.10",
     "miniflare": "^2.14.1",
     "typescript": "^5.3.3",
     "vitest": "^1.2.0",
@@ -20,6 +21,7 @@
     "@ensdomains/ensjs": "^3.5.0-beta.1",
     "@noble/hashes": "^1.3.1",
     "itty-router": "^4.0.27",
+    "valibot": "^0.35.0",
     "viem": "^2.7.19"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ dependencies:
   itty-router:
     specifier: ^4.0.27
     version: 4.0.27
+  valibot:
+    specifier: ^0.35.0
+    version: 0.35.0
   viem:
     specifier: ^2.7.19
     version: 2.7.19(typescript@5.3.3)
@@ -22,6 +25,9 @@ devDependencies:
   '@cloudflare/workers-types':
     specifier: ^4.20231218.0
     version: 4.20231218.0
+  '@viem/anvil':
+    specifier: ^0.0.10
+    version: 0.0.10
   miniflare:
     specifier: ^2.14.1
     version: 2.14.1
@@ -997,6 +1003,19 @@ packages:
     resolution: {integrity: sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g==}
     dev: true
 
+  /@viem/anvil@0.0.10:
+    resolution: {integrity: sha512-9PzYXBRikfSUhhm8Bd0avv07agwcbMJ5FaSu2D2vbE0cxkvXGtolL3fW5nz2yefMqOqVQL4XzfM5nwY81x3ytw==}
+    dependencies:
+      execa: 7.2.0
+      get-port: 6.1.2
+      http-proxy: 1.18.1
+      ws: 8.13.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+    dev: true
+
   /@vitest/expect@1.2.0:
     resolution: {integrity: sha512-H+2bHzhyvgp32o7Pgj2h9RTHN0pgYaoi26Oo3mE+dCi1PAqV31kIIVfTbqMO3Bvshd5mIrJLc73EwSRrbol9Lw==}
     dependencies:
@@ -1343,6 +1362,10 @@ packages:
       '@types/estree': 1.0.5
     dev: true
 
+  /eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+    dev: true
+
   /execa@6.1.0:
     resolution: {integrity: sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1350,6 +1373,21 @@ packages:
       cross-spawn: 7.0.3
       get-stream: 6.0.1
       human-signals: 3.0.1
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.1.0
+      onetime: 6.0.0
+      signal-exit: 3.0.7
+      strip-final-newline: 3.0.0
+    dev: true
+
+  /execa@7.2.0:
+    resolution: {integrity: sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==}
+    engines: {node: ^14.18.0 || ^16.14.0 || >=18.0.0}
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 6.0.1
+      human-signals: 4.3.1
       is-stream: 3.0.0
       merge-stream: 2.0.0
       npm-run-path: 5.1.0
@@ -1385,6 +1423,16 @@ packages:
       to-regex-range: 5.0.1
     dev: true
 
+  /follow-redirects@1.15.6:
+    resolution: {integrity: sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: true
+
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1395,6 +1443,11 @@ packages:
 
   /get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+    dev: true
+
+  /get-port@6.1.2:
+    resolution: {integrity: sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
   /get-source@2.0.12:
@@ -1450,9 +1503,25 @@ packages:
     resolution: {integrity: sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==}
     dev: true
 
+  /http-proxy@1.18.1:
+    resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      eventemitter3: 4.0.7
+      follow-redirects: 1.15.6
+      requires-port: 1.0.0
+    transitivePeerDependencies:
+      - debug
+    dev: true
+
   /human-signals@3.0.1:
     resolution: {integrity: sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==}
     engines: {node: '>=12.20.0'}
+    dev: true
+
+  /human-signals@4.3.1:
+    resolution: {integrity: sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==}
+    engines: {node: '>=14.18.0'}
     dev: true
 
   /human-signals@5.0.0:
@@ -1790,6 +1859,10 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+    dev: true
+
   /resolve.exports@2.0.2:
     resolution: {integrity: sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==}
     engines: {node: '>=10'}
@@ -2055,6 +2128,10 @@ packages:
   /urlpattern-polyfill@4.0.3:
     resolution: {integrity: sha512-DOE84vZT2fEcl9gqCUTcnAw5ZY5Id55ikUcziSUntuEFL3pRvavg5kwDmTEUJkeCHInTlV/HexFomgYnzO5kdQ==}
     dev: true
+
+  /valibot@0.35.0:
+    resolution: {integrity: sha512-+i2aCRkReTrd5KBN/dW2BrPOvFnU5LXTV2xjZnjnqUIO8YUx6P2+MgRrkwF2FhkexgyKq/NIZdPdknhHf5A/Ww==}
+    dev: false
 
   /validate-npm-package-name@4.0.0:
     resolution: {integrity: sha512-mzR0L8ZDktZjpX4OB46KT+56MAhl4EIazWP/+G/HPGuvfdaqg4YsCdtOm6U9+LOFyYDoh4dpnpxZRB9MQQns5Q==}

--- a/src/put.ts
+++ b/src/put.ts
@@ -1,11 +1,12 @@
 import { sha256 } from "@noble/hashes/sha256";
 import { json } from "itty-router";
 import { error } from "itty-router/error";
-import { bytesToHex, recoverTypedDataAddress } from "viem";
+import * as v from "valibot";
+import { bytesToHex, isAddress, type Address, type Hex } from "viem";
 import { normalize } from "viem/ens";
 import { ValidatedRequest } from "./chains";
-import { AvatarUploadParams, Env } from "./types";
-import { getOwnerAndAvailable } from "./utils";
+import { Env } from "./types";
+import { getOwnerAndAvailable, getVerifiedAddress } from "./utils";
 
 const dataURLToBytes = (dataURL: string) => {
   const base64 = dataURL.split(",")[1];
@@ -14,56 +15,57 @@ const dataURLToBytes = (dataURL: string) => {
   return { mime, bytes };
 };
 
+const UploadSchema = v.object({
+  expiry: v.pipe(
+    v.string("expiry value is missing"),
+    v.regex(/^\d+$/, "expiry value is not number")
+  ),
+  dataURL: v.string("dataURL value is missing"),
+  sig: v.pipe(
+    v.string("sig value is missing"),
+    v.hexadecimal<Hex, string>("sig value is not hex")
+  ),
+  unverifiedAddress: v.pipe(
+    v.string("unverifiedAddress value is missing"),
+    v.hexadecimal("unverifiedAddress value is not hex"),
+    v.check<Address, string>(
+      isAddress,
+      "unverifiedAddress value is not address"
+    )
+  ),
+});
+
 export const handlePut = async (request: ValidatedRequest, env: Env) => {
   const { name, network, chain } = request;
-  const { expiry, dataURL, sig } = (await request.json()) as AvatarUploadParams;
+
+  const { success, output } = v.safeParse(UploadSchema, await request.json());
+  if (!success) return error(400, "Request is missing parameters");
+  const { expiry, dataURL, sig, unverifiedAddress } = output;
+
   const { mime, bytes } = dataURLToBytes(dataURL);
   const hash = bytesToHex(sha256(bytes));
 
-  if (mime !== "image/jpeg") {
+  if (mime !== "image/jpeg")
     return error(415, "File must be of type image/jpeg");
-  }
 
-  if (name !== normalize(name)) {
+  if (name !== normalize(name))
     return error(400, "Name must be in normalized form");
-  }
 
-  const verifiedAddress = await recoverTypedDataAddress({
-    domain: {
-      name: "Ethereum Name Service",
-      version: "1",
-    },
-    types: {
-      Upload: [
-        { name: "upload", type: "string" },
-        { name: "expiry", type: "string" },
-        { name: "name", type: "string" },
-        { name: "hash", type: "string" },
-      ],
-    },
-    primaryType: "Upload",
-    signature: sig,
-    message: {
-      upload: "avatar",
-      expiry,
-      name,
-      hash,
-    },
-  }).catch((e) => {
-    console.error("Error while recovering typed data address");
-    console.error(e);
-    return null;
+  const verifiedAddress = await getVerifiedAddress({
+    env,
+    chain,
+    sig,
+    expiry,
+    name,
+    hash,
+    unverifiedAddress,
   });
 
-  if (!verifiedAddress) {
-    return error(400, "Invalid signature");
-  }
+  if (!verifiedAddress) return error(400, "Invalid signature");
 
   const maxSize = 1024 * 512;
 
-  if (bytes.byteLength > maxSize) {
-    return error(413, "Image is too large");
-  }
+  if (bytes.byteLength > maxSize) return error(413, "Image is too large");
 
   const { available, owner } = await getOwnerAndAvailable({ env, chain, name });
 
@@ -78,9 +80,7 @@ export const handlePut = async (request: ValidatedRequest, env: Env) => {
     }
   }
 
-  if (parseInt(expiry) < Date.now()) {
-    return error(403, "Signature expired");
-  }
+  if (parseInt(expiry) < Date.now()) return error(403, "Signature expired");
 
   const bucket = env.AVATAR_BUCKET;
   const key = available

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Hex } from "viem";
+import type { Address, Hex } from "viem";
 
 export interface Env {
   // Example binding to KV. Learn more at https://developers.cloudflare.com/workers/runtime-apis/kv/
@@ -19,4 +19,5 @@ export type AvatarUploadParams = {
   expiry: string;
   dataURL: string;
   sig: Hex;
+  unverifiedAddress: Address;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,8 @@
 import type { Env } from "./types";
 
 import { getAvailable, getOwner } from "@ensdomains/ensjs/public";
+import { getAddress, type Address, type Hex } from "viem";
+import { verifyTypedData } from "viem/actions";
 import { getClient, type chains } from "./chains";
 
 export const getOwnerAndAvailable = async ({
@@ -26,4 +28,59 @@ export const getOwnerAndAvailable = async ({
     owner: ownership?.owner ?? null,
     available,
   };
+};
+
+export const typedDataParameters = {
+  domain: {
+    name: "Ethereum Name Service",
+    version: "1",
+  },
+  types: {
+    Upload: [
+      { name: "upload", type: "string" },
+      { name: "expiry", type: "string" },
+      { name: "name", type: "string" },
+      { name: "hash", type: "string" },
+    ],
+  },
+  primaryType: "Upload",
+} as const;
+
+export const getVerifiedAddress = async ({
+  env,
+  chain,
+  sig,
+  expiry,
+  name,
+  hash,
+  unverifiedAddress,
+}: {
+  env: Env;
+  chain: (typeof chains)[number];
+  sig: Hex;
+  expiry: string;
+  name: string;
+  hash: Hex;
+  unverifiedAddress: Address;
+}) => {
+  const client = getClient({ env, chain });
+  const address = getAddress(unverifiedAddress);
+
+  const valid = await verifyTypedData(client, {
+    ...typedDataParameters,
+    address,
+    signature: sig,
+    message: {
+      upload: "avatar",
+      expiry,
+      name,
+      hash,
+    },
+  }).catch((e) => {
+    console.error("Error while verifying typed data");
+    console.error(e);
+    return false;
+  });
+
+  return valid ? address : null;
 };


### PR DESCRIPTION
now using `verifyTypedData` action from viem, which uses a deployless universal signature validator contract which is compatible with smart contract accounts.

given the signature validator contract, we can no longer recover the address from a signature and as such the address is now required as a parameter to verify against.