### PR TITLE
feat: WebSocket events for avatar/header changes via Durable Object

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "generate-types": "wrangler types",
         "type-check": "pnpm generate-types && tsc",
         "lint": "eslint -c eslint.config.mjs",
-        "test": "vitest"
+        "test": "vitest --run && vitest --run --config vitest.config.do.ts"
     },
     "dependencies": {
         "@ensdomains/ensjs": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
         "generate-types": "wrangler types",
         "type-check": "pnpm generate-types && tsc",
         "lint": "eslint -c eslint.config.mjs",
-        "test": "vitest --run && vitest --run --config vitest.config.do.ts"
+        "test": "pnpm test:unit && pnpm test:do",
+        "test:unit": "vitest --run",
+        "test:do": "vitest --run --config vitest.config.do.ts"
     },
     "dependencies": {
         "@ensdomains/ensjs": "^4.0.2",

--- a/src/durable-objects/media-notifier.ts
+++ b/src/durable-objects/media-notifier.ts
@@ -33,7 +33,7 @@ export class MediaNotifier extends DurableObject<Env> {
   }
 
   #subscribe(req: Request, url: URL): Response {
-    if (req.headers.get("Upgrade") !== "websocket") {
+    if (req.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
       return new Response("expected websocket", { status: 426 });
     }
 

--- a/src/durable-objects/media-notifier.ts
+++ b/src/durable-objects/media-notifier.ts
@@ -25,10 +25,12 @@ export class MediaNotifier extends DurableObject<Env> {
   // SQLite-backed persistence for v1.
   #subscribers: Map<string, Set<WebSocket>> = new Map();
 
+  // Only the WebSocket upgrade is HTTP. `notify` is exposed as an RPC method
+  // below so the worker can invoke it through the typed stub without going
+  // through HTTP.
   override async fetch(req: Request): Promise<Response> {
     const url = new URL(req.url);
     if (url.pathname === "/subscribe") return this.#subscribe(req, url);
-    if (url.pathname === "/notify") return this.#notify(req);
     return new Response("not found", { status: 404 });
   }
 
@@ -69,8 +71,7 @@ export class MediaNotifier extends DurableObject<Env> {
     return new Response(null, { status: 101, webSocket: client });
   }
 
-  async #notify(req: Request): Promise<Response> {
-    const payload = (await req.json()) as ChangePayload;
+  async notify(payload: ChangePayload): Promise<{ delivered: number }> {
     const message = JSON.stringify(payload);
     const tag = tagFor(payload.network, payload.name, payload.mediaType);
     const bucket = this.#subscribers.get(tag);
@@ -88,6 +89,6 @@ export class MediaNotifier extends DurableObject<Env> {
       }
     }
 
-    return new Response(null, { status: 204, headers: { "X-Delivered": String(delivered) } });
+    return { delivered };
   }
 }

--- a/src/durable-objects/media-notifier.ts
+++ b/src/durable-objects/media-notifier.ts
@@ -19,18 +19,13 @@ export type ChangePayload = {
 const NETWORKS = new Set<Network>(["mainnet", "goerli", "sepolia", "holesky", "localhost"]);
 const MEDIA_TYPES = new Set<MediaType>(["avatar", "header"]);
 
+// ":" is rejected by ENSIP-15 normalization, so the separator is unambiguous.
 const tagFor = (network: Network, name: string, mediaType: MediaType) =>
   `${network}:${name}:${mediaType}`;
 
 export class MediaNotifier extends DurableObject<Env> {
-  // Plain in-memory subscriber map. The DO is a single global instance that
-  // stays alive while clients are connected, so we don't need hibernation or
-  // SQLite-backed persistence for v1.
   #subscribers: Map<string, Set<WebSocket>> = new Map();
 
-  // Only the WebSocket upgrade is HTTP. `notify` is exposed as an RPC method
-  // below so the worker can invoke it through the typed stub without going
-  // through HTTP.
   override async fetch(req: Request): Promise<Response> {
     const url = new URL(req.url);
     if (url.pathname === "/subscribe") return this.#subscribe(req, url);

--- a/src/durable-objects/media-notifier.ts
+++ b/src/durable-objects/media-notifier.ts
@@ -1,0 +1,93 @@
+import { DurableObject } from "cloudflare:workers";
+import type { Address, Hex } from "viem";
+import type { Network } from "@/utils/chains";
+import type { MediaType } from "@/utils/media";
+
+export type ChangePayload = {
+  type: "media.changed";
+  mediaType: MediaType;
+  network: Network;
+  name: string;
+  hash: Hex;
+  size: number;
+  key: string;
+  address: Address;
+  source: "upload" | "promotion";
+  timestamp: number;
+};
+
+const tagFor = (network: Network, name: string, mediaType: MediaType) =>
+  `${network}:${name}:${mediaType}`;
+
+export class MediaNotifier extends DurableObject<Env> {
+  // Plain in-memory subscriber map. The DO is a single global instance that
+  // stays alive while clients are connected, so we don't need hibernation or
+  // SQLite-backed persistence for v1.
+  #subscribers: Map<string, Set<WebSocket>> = new Map();
+
+  override async fetch(req: Request): Promise<Response> {
+    const url = new URL(req.url);
+    if (url.pathname === "/subscribe") return this.#subscribe(req, url);
+    if (url.pathname === "/notify") return this.#notify(req);
+    return new Response("not found", { status: 404 });
+  }
+
+  #subscribe(req: Request, url: URL): Response {
+    if (req.headers.get("Upgrade") !== "websocket") {
+      return new Response("expected websocket", { status: 426 });
+    }
+
+    const network = url.searchParams.get("network") as Network | null;
+    const name = url.searchParams.get("name");
+    const mediaType = url.searchParams.get("mediaType") as MediaType | null;
+
+    if (!network || !name || !mediaType) {
+      return new Response("missing subscription params", { status: 400 });
+    }
+
+    const pair = new WebSocketPair();
+    const [client, server] = Object.values(pair);
+
+    server.accept();
+    const tag = tagFor(network, name, mediaType);
+    let bucket = this.#subscribers.get(tag);
+    if (!bucket) {
+      bucket = new Set();
+      this.#subscribers.set(tag, bucket);
+    }
+    bucket.add(server);
+
+    const cleanup = () => {
+      bucket?.delete(server);
+      if (bucket && bucket.size === 0) this.#subscribers.delete(tag);
+    };
+    server.addEventListener("close", cleanup);
+    server.addEventListener("error", cleanup);
+
+    server.send(JSON.stringify({ type: "hello", protocol: 1 }));
+
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  async #notify(req: Request): Promise<Response> {
+    const payload = (await req.json()) as ChangePayload;
+    const message = JSON.stringify(payload);
+    const tag = tagFor(payload.network, payload.name, payload.mediaType);
+    const bucket = this.#subscribers.get(tag);
+
+    let delivered = 0;
+    if (bucket) {
+      for (const ws of bucket) {
+        try {
+          ws.send(message);
+          delivered += 1;
+        }
+        catch {
+          bucket.delete(ws);
+        }
+      }
+    }
+
+    return new Response(null, { status: 204, headers: { "X-Delivered": String(delivered) } });
+  }
+}

--- a/src/durable-objects/media-notifier.ts
+++ b/src/durable-objects/media-notifier.ts
@@ -16,6 +16,9 @@ export type ChangePayload = {
   timestamp: number;
 };
 
+const NETWORKS = new Set<Network>(["mainnet", "goerli", "sepolia", "holesky", "localhost"]);
+const MEDIA_TYPES = new Set<MediaType>(["avatar", "header"]);
+
 const tagFor = (network: Network, name: string, mediaType: MediaType) =>
   `${network}:${name}:${mediaType}`;
 
@@ -39,19 +42,24 @@ export class MediaNotifier extends DurableObject<Env> {
       return new Response("expected websocket", { status: 426 });
     }
 
-    const network = url.searchParams.get("network") as Network | null;
+    const network = url.searchParams.get("network");
     const name = url.searchParams.get("name");
-    const mediaType = url.searchParams.get("mediaType") as MediaType | null;
+    const mediaType = url.searchParams.get("mediaType");
 
-    if (!network || !name || !mediaType) {
-      return new Response("missing subscription params", { status: 400 });
+    if (!name || !network || !NETWORKS.has(network as Network)) {
+      return new Response("invalid network or name", { status: 400 });
     }
+    if (!mediaType || !MEDIA_TYPES.has(mediaType as MediaType)) {
+      return new Response("invalid mediaType", { status: 400 });
+    }
+
+    const tag = tagFor(network as Network, name, mediaType as MediaType);
 
     const pair = new WebSocketPair();
     const [client, server] = Object.values(pair);
 
     server.accept();
-    const tag = tagFor(network, name, mediaType);
+
     let bucket = this.#subscribers.get(tag);
     if (!bucket) {
       bucket = new Set();
@@ -60,8 +68,10 @@ export class MediaNotifier extends DurableObject<Env> {
     bucket.add(server);
 
     const cleanup = () => {
-      bucket?.delete(server);
-      if (bucket && bucket.size === 0) this.#subscribers.delete(tag);
+      const current = this.#subscribers.get(tag);
+      if (!current) return;
+      current.delete(server);
+      if (current.size === 0) this.#subscribers.delete(tag);
     };
     server.addEventListener("close", cleanup);
     server.addEventListener("error", cleanup);

--- a/src/durable-objects/media-notifier.ts
+++ b/src/durable-objects/media-notifier.ts
@@ -19,6 +19,10 @@ export type ChangePayload = {
 const NETWORKS = new Set<Network>(["mainnet", "goerli", "sepolia", "holesky", "localhost"]);
 const MEDIA_TYPES = new Set<MediaType>(["avatar", "header"]);
 
+// Firehose subscribers land here. Real tags are always `network:name:mediaType`,
+// so "*" can never collide with one.
+const GLOBAL_TAG = "*";
+
 // ":" is rejected by ENSIP-15 normalization, so the separator is unambiguous.
 const tagFor = (network: Network, name: string, mediaType: MediaType) =>
   `${network}:${name}:${mediaType}`;
@@ -37,24 +41,36 @@ export class MediaNotifier extends DurableObject<Env> {
       return new Response("expected websocket", { status: 426 });
     }
 
-    const network = url.searchParams.get("network");
-    const name = url.searchParams.get("name");
-    const mediaType = url.searchParams.get("mediaType");
-
-    if (!name || !network || !NETWORKS.has(network as Network)) {
-      return new Response("invalid network or name", { status: 400 });
+    let tag: string;
+    if (url.searchParams.get("scope") === "global") {
+      tag = GLOBAL_TAG;
     }
-    if (!mediaType || !MEDIA_TYPES.has(mediaType as MediaType)) {
-      return new Response("invalid mediaType", { status: 400 });
-    }
+    else {
+      const network = url.searchParams.get("network");
+      const name = url.searchParams.get("name");
+      const mediaType = url.searchParams.get("mediaType");
 
-    const tag = tagFor(network as Network, name, mediaType as MediaType);
+      if (!name || !network || !NETWORKS.has(network as Network)) {
+        return new Response("invalid network or name", { status: 400 });
+      }
+      if (!mediaType || !MEDIA_TYPES.has(mediaType as MediaType)) {
+        return new Response("invalid mediaType", { status: 400 });
+      }
+
+      tag = tagFor(network as Network, name, mediaType as MediaType);
+    }
 
     const pair = new WebSocketPair();
     const [client, server] = Object.values(pair);
 
     server.accept();
+    this.#addSubscriber(tag, server);
+    server.send(JSON.stringify({ type: "hello", protocol: 1 }));
 
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  #addSubscriber(tag: string, server: WebSocket): void {
     let bucket = this.#subscribers.get(tag);
     if (!bucket) {
       bucket = new Set();
@@ -70,30 +86,31 @@ export class MediaNotifier extends DurableObject<Env> {
     };
     server.addEventListener("close", cleanup);
     server.addEventListener("error", cleanup);
-
-    server.send(JSON.stringify({ type: "hello", protocol: 1 }));
-
-    return new Response(null, { status: 101, webSocket: client });
   }
 
   async notify(payload: ChangePayload): Promise<{ delivered: number }> {
     const message = JSON.stringify(payload);
     const tag = tagFor(payload.network, payload.name, payload.mediaType);
-    const bucket = this.#subscribers.get(tag);
 
+    return {
+      delivered:
+        this.#send(message, this.#subscribers.get(tag))
+        + this.#send(message, this.#subscribers.get(GLOBAL_TAG)),
+    };
+  }
+
+  #send(message: string, bucket: Set<WebSocket> | undefined): number {
+    if (!bucket) return 0;
     let delivered = 0;
-    if (bucket) {
-      for (const ws of bucket) {
-        try {
-          ws.send(message);
-          delivered += 1;
-        }
-        catch {
-          bucket.delete(ws);
-        }
+    for (const ws of bucket) {
+      try {
+        ws.send(message);
+        delivered += 1;
+      }
+      catch {
+        bucket.delete(ws);
       }
     }
-
-    return { delivered };
+    return delivered;
   }
 }

--- a/src/durable-objects/media-notifier.ts
+++ b/src/durable-objects/media-notifier.ts
@@ -63,6 +63,11 @@ export class MediaNotifier extends DurableObject<Env> {
     const pair = new WebSocketPair();
     const [client, server] = Object.values(pair);
 
+    // Standard accept() (not the hibernation API) keeps the DO in memory while
+    // any socket is open, so the in-memory subscriber map can't desync via
+    // eviction. Hibernation would cut idle cost but is deferred: the pinned
+    // vitest-pool-workers version can't exercise it, and a single global DO
+    // rarely idles, so the saving would be small.
     server.accept();
     this.#addSubscriber(tag, server);
     server.send(JSON.stringify({ type: "hello", protocol: 1 }));

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,10 @@ import { createApp } from "./utils/hono";
 import { NetworkMiddlewareEnv, networkMiddleware } from "./utils/chains";
 import avatarRouter from "./routes/avatar";
 import headerRouter from "./routes/header";
+import eventsRouter from "./routes/events";
 import { cors } from "hono/cors";
+
+export { MediaNotifier } from "./durable-objects/media-notifier";
 
 const PROD_ALLOWED_ORIGIN_SUFFIXES = [
   "ens.domains",
@@ -50,6 +53,7 @@ const networkRouter = createApp<NetworkMiddlewareEnv>().use(networkMiddleware);
 
 networkRouter.route("/", avatarRouter);
 networkRouter.route("/", headerRouter);
+networkRouter.route("/", eventsRouter);
 
 app.route("/", networkRouter);
 app.route("/:network", networkRouter);

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,41 +14,47 @@ const PROD_ALLOWED_ORIGIN_SUFFIXES = [
   "ens-app-v3.pages.dev",
   "grails.app",
   "efp.app",
-  "ethleaderboard.com"
+  "ethleaderboard.com",
 ] as const;
 
 const app = createApp();
-app.use(
-  "*",
-  cors({
-    origin: (origin, c) => {
-      const requestOrigin = c.req.header("Origin") || "";
-      // We rely on ENVIRONMENT from wrangler config
-      const isProd = c.env.ENVIRONMENT === "production";
+const corsMiddleware = cors({
+  origin: (origin, c) => {
+    const requestOrigin = c.req.header("Origin") || "";
+    // We rely on ENVIRONMENT from wrangler config
+    const isProd = c.env.ENVIRONMENT === "production";
 
-      // If production environment: only allow subdomains of approved suffixes
-      if (isProd) {
-        try {
-          const hostname = new URL(requestOrigin).hostname;
-          const allows = (host: string, suffix: string) =>
-            host === suffix || host.endsWith(`.${suffix}`);
+    // If production environment: only allow subdomains of approved suffixes
+    if (isProd) {
+      try {
+        const hostname = new URL(requestOrigin).hostname;
+        const allows = (host: string, suffix: string) =>
+          host === suffix || host.endsWith(`.${suffix}`);
 
-          if (PROD_ALLOWED_ORIGIN_SUFFIXES.some(suffix => allows(hostname, suffix))) {
-            return requestOrigin; // reflect approved origin
-          }
+        if (PROD_ALLOWED_ORIGIN_SUFFIXES.some(suffix => allows(hostname, suffix))) {
+          return requestOrigin; // reflect approved origin
         }
-        catch {
-          // If it's not a valid URL, deny
-        }
-        return ""; // empty => disallowed
       }
+      catch {
+        // If it's not a valid URL, deny
+      }
+      return ""; // empty => disallowed
+    }
 
-      // Otherwise (development), allow all
-      return "*";
-    },
-    allowMethods: ["GET", "PUT", "POST", "OPTIONS", "DELETE"],
-  }),
-);
+    // Otherwise (development), allow all
+    return "*";
+  },
+  allowMethods: ["GET", "PUT", "POST", "OPTIONS", "DELETE"],
+});
+
+// Skip CORS for WebSocket upgrades — Hono's cors middleware tries to clone
+// the 101 response to inject headers, and Response cannot be constructed with
+// a 1xx status. Browsers don't apply CORS to WS handshakes anyway; the Origin
+// header is checked at upgrade time by the subscription handler if needed.
+app.use("*", async (c, next) => {
+  if (c.req.header("Upgrade")?.toLowerCase() === "websocket") return next();
+  return corsMiddleware(c, next);
+});
 const networkRouter = createApp<NetworkMiddlewareEnv>().use(networkMiddleware);
 
 networkRouter.route("/", avatarRouter);

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,10 +21,8 @@ const app = createApp();
 const corsMiddleware = cors({
   origin: (origin, c) => {
     const requestOrigin = c.req.header("Origin") || "";
-    // We rely on ENVIRONMENT from wrangler config
     const isProd = c.env.ENVIRONMENT === "production";
 
-    // If production environment: only allow subdomains of approved suffixes
     if (isProd) {
       try {
         const hostname = new URL(requestOrigin).hostname;
@@ -32,25 +30,21 @@ const corsMiddleware = cors({
           host === suffix || host.endsWith(`.${suffix}`);
 
         if (PROD_ALLOWED_ORIGIN_SUFFIXES.some(suffix => allows(hostname, suffix))) {
-          return requestOrigin; // reflect approved origin
+          return requestOrigin;
         }
       }
       catch {
-        // If it's not a valid URL, deny
+        // not a valid URL
       }
-      return ""; // empty => disallowed
+      return "";
     }
 
-    // Otherwise (development), allow all
     return "*";
   },
   allowMethods: ["GET", "PUT", "POST", "OPTIONS", "DELETE"],
 });
 
-// Skip CORS for WebSocket upgrades — Hono's cors middleware tries to clone
-// the 101 response to inject headers, and Response cannot be constructed with
-// a 1xx status. Browsers don't apply CORS to WS handshakes anyway; the Origin
-// header is checked at upgrade time by the subscription handler if needed.
+// Hono's cors clones the route response to inject headers; cloning a 101 fails because Response forbids 1xx.
 app.use("*", async (c, next) => {
   if (c.req.header("Upgrade")?.toLowerCase() === "websocket") return next();
   return corsMiddleware(c, next);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { createApp } from "./utils/hono";
 import { NetworkMiddlewareEnv, networkMiddleware } from "./utils/chains";
 import avatarRouter from "./routes/avatar";
 import headerRouter from "./routes/header";
-import eventsRouter from "./routes/events";
+import eventsRouter, { globalEventsHandler } from "./routes/events";
 import { cors } from "hono/cors";
 
 export { MediaNotifier } from "./durable-objects/media-notifier";
@@ -49,6 +49,12 @@ app.use("*", async (c, next) => {
   if (c.req.header("Upgrade")?.toLowerCase() === "websocket") return next();
   return corsMiddleware(c, next);
 });
+
+// Cross-network firehose. Registered before the :name routers so the static
+// path wins over the /:name wildcard. Network-agnostic, so it sits outside the
+// network middleware.
+app.get("/events", globalEventsHandler);
+
 const networkRouter = createApp<NetworkMiddlewareEnv>().use(networkMiddleware);
 
 networkRouter.route("/", avatarRouter);

--- a/src/routes/avatar.ts
+++ b/src/routes/avatar.ts
@@ -1,6 +1,6 @@
 import { vValidator } from "@hono/valibot-validator";
 import * as v from "valibot";
-import { createApp } from "@/utils/hono";
+import { createApp, getExecutionCtx } from "@/utils/hono";
 import { clientMiddleware, NetworkMiddlewareEnv } from "@/utils/chains";
 import { Address, isAddress, sha256 } from "viem";
 import { Hex } from "viem";
@@ -12,6 +12,7 @@ import {
   findAndPromoteUnregisteredMedia,
   MEDIA_BUCKET_KEY,
 } from "@/utils/media";
+import { notifyMediaChanged } from "@/utils/notify";
 import { isParentOwner, isSubname } from "@/utils/subname";
 
 const router = createApp<NetworkMiddlewareEnv>();
@@ -64,6 +65,7 @@ router.get("/:name", clientMiddleware, async (c) => {
     name,
     client,
     mediaType: "avatar",
+    executionCtx: getExecutionCtx(c),
   });
 
   if (unregisteredAvatar) {
@@ -151,6 +153,18 @@ router.put(
     });
 
     if (uploaded.key === key) {
+      getExecutionCtx(c).waitUntil(notifyMediaChanged(c.env, {
+        type: "media.changed",
+        mediaType: "avatar",
+        network,
+        name,
+        hash,
+        size: bytes.byteLength,
+        key,
+        address: verifiedAddress,
+        source: "upload",
+        timestamp: Date.now(),
+      }));
       return c.json({ message: "uploaded" }, 200);
     }
     else {

--- a/src/routes/avatar.ts
+++ b/src/routes/avatar.ts
@@ -150,6 +150,7 @@ router.put(
 
     const uploaded = await bucket.put(key, bytes, {
       httpMetadata: { contentType: "image/jpeg" },
+      sha256: hash.slice(2),
     });
 
     if (uploaded.key === key) {

--- a/src/routes/avatar.ts
+++ b/src/routes/avatar.ts
@@ -1,6 +1,6 @@
 import { vValidator } from "@hono/valibot-validator";
 import * as v from "valibot";
-import { createApp, getExecutionCtx } from "@/utils/hono";
+import { createApp, waitUntil } from "@/utils/hono";
 import { clientMiddleware, NetworkMiddlewareEnv } from "@/utils/chains";
 import { Address, isAddress, sha256 } from "viem";
 import { Hex } from "viem";
@@ -65,7 +65,7 @@ router.get("/:name", clientMiddleware, async (c) => {
     name,
     client,
     mediaType: "avatar",
-    executionCtx: getExecutionCtx(c),
+    waitUntil: p => waitUntil(c, p),
   });
 
   if (unregisteredAvatar) {
@@ -154,7 +154,7 @@ router.put(
     });
 
     if (uploaded.key === key) {
-      getExecutionCtx(c).waitUntil(notifyMediaChanged(c.env, {
+      waitUntil(c, notifyMediaChanged(c.env, {
         type: "media.changed",
         mediaType: "avatar",
         network,

--- a/src/routes/events.ts
+++ b/src/routes/events.ts
@@ -6,7 +6,7 @@ import type { MediaType } from "@/utils/media";
 const router = createApp<NetworkMiddlewareEnv>();
 
 const subscribeHandler = (mediaType: MediaType) => (c: Context<BaseEnv & NetworkMiddlewareEnv>) => {
-  if (c.req.header("Upgrade") !== "websocket") {
+  if (c.req.header("Upgrade")?.toLowerCase() !== "websocket") {
     return c.text("expected websocket", 426);
   }
 

--- a/src/routes/events.ts
+++ b/src/routes/events.ts
@@ -1,0 +1,40 @@
+import { createApp } from "@/utils/hono";
+import type { Network, NetworkMiddlewareEnv } from "@/utils/chains";
+import type { MediaType } from "@/utils/media";
+
+const router = createApp<NetworkMiddlewareEnv>();
+
+const buildSubscribeRequest = (
+  req: Request,
+  network: Network,
+  name: string,
+  mediaType: MediaType,
+) => {
+  const url = new URL("https://do/subscribe");
+  url.searchParams.set("network", network);
+  url.searchParams.set("name", name);
+  url.searchParams.set("mediaType", mediaType);
+  return new Request(url, req);
+};
+
+router.get("/:name/events", (c) => {
+  if (c.req.header("Upgrade") !== "websocket") {
+    return c.text("expected websocket", 426);
+  }
+  const id = c.env.MEDIA_NOTIFIER.idFromName("global");
+  return c.env.MEDIA_NOTIFIER
+    .get(id)
+    .fetch(buildSubscribeRequest(c.req.raw, c.var.network, c.req.param("name"), "avatar"));
+});
+
+router.get("/:name/h/events", (c) => {
+  if (c.req.header("Upgrade") !== "websocket") {
+    return c.text("expected websocket", 426);
+  }
+  const id = c.env.MEDIA_NOTIFIER.idFromName("global");
+  return c.env.MEDIA_NOTIFIER
+    .get(id)
+    .fetch(buildSubscribeRequest(c.req.raw, c.var.network, c.req.param("name"), "header"));
+});
+
+export default router;

--- a/src/routes/events.ts
+++ b/src/routes/events.ts
@@ -1,40 +1,25 @@
-import { createApp } from "@/utils/hono";
-import type { Network, NetworkMiddlewareEnv } from "@/utils/chains";
+import type { Context } from "hono";
+import { BaseEnv, createApp } from "@/utils/hono";
+import { type NetworkMiddlewareEnv } from "@/utils/chains";
 import type { MediaType } from "@/utils/media";
 
 const router = createApp<NetworkMiddlewareEnv>();
 
-const buildSubscribeRequest = (
-  req: Request,
-  network: Network,
-  name: string,
-  mediaType: MediaType,
-) => {
+const subscribeHandler = (mediaType: MediaType) => (c: Context<BaseEnv & NetworkMiddlewareEnv>) => {
+  if (c.req.header("Upgrade") !== "websocket") {
+    return c.text("expected websocket", 426);
+  }
+
   const url = new URL("https://do/subscribe");
-  url.searchParams.set("network", network);
-  url.searchParams.set("name", name);
+  url.searchParams.set("network", c.var.network);
+  url.searchParams.set("name", c.req.param("name"));
   url.searchParams.set("mediaType", mediaType);
-  return new Request(url, req);
+
+  const id = c.env.MEDIA_NOTIFIER.idFromName("global");
+  return c.env.MEDIA_NOTIFIER.get(id).fetch(new Request(url, c.req.raw));
 };
 
-router.get("/:name/events", (c) => {
-  if (c.req.header("Upgrade") !== "websocket") {
-    return c.text("expected websocket", 426);
-  }
-  const id = c.env.MEDIA_NOTIFIER.idFromName("global");
-  return c.env.MEDIA_NOTIFIER
-    .get(id)
-    .fetch(buildSubscribeRequest(c.req.raw, c.var.network, c.req.param("name"), "avatar"));
-});
-
-router.get("/:name/h/events", (c) => {
-  if (c.req.header("Upgrade") !== "websocket") {
-    return c.text("expected websocket", 426);
-  }
-  const id = c.env.MEDIA_NOTIFIER.idFromName("global");
-  return c.env.MEDIA_NOTIFIER
-    .get(id)
-    .fetch(buildSubscribeRequest(c.req.raw, c.var.network, c.req.param("name"), "header"));
-});
+router.get("/:name/events", subscribeHandler("avatar"));
+router.get("/:name/h/events", subscribeHandler("header"));
 
 export default router;

--- a/src/routes/events.ts
+++ b/src/routes/events.ts
@@ -3,23 +3,37 @@ import { BaseEnv, createApp } from "@/utils/hono";
 import { type NetworkMiddlewareEnv } from "@/utils/chains";
 import type { MediaType } from "@/utils/media";
 
-const router = createApp<NetworkMiddlewareEnv>();
-
-const subscribeHandler = (mediaType: MediaType) => (c: Context<BaseEnv & NetworkMiddlewareEnv>) => {
-  if (c.req.header("Upgrade")?.toLowerCase() !== "websocket") {
-    return c.text("expected websocket", 426);
+const forwardSubscribe = (
+  req: Request,
+  notifier: Env["MEDIA_NOTIFIER"],
+  params: Record<string, string>,
+): Response | Promise<Response> => {
+  if (req.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
+    return new Response("expected websocket", { status: 426 });
   }
 
   const url = new URL("https://do/subscribe");
-  url.searchParams.set("network", c.var.network);
-  url.searchParams.set("name", c.req.param("name"));
-  url.searchParams.set("mediaType", mediaType);
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
 
-  const id = c.env.MEDIA_NOTIFIER.idFromName("global");
-  return c.env.MEDIA_NOTIFIER.get(id).fetch(new Request(url, c.req.raw));
+  return notifier.get(notifier.idFromName("global")).fetch(new Request(url, req));
 };
+
+const router = createApp<NetworkMiddlewareEnv>();
+
+const subscribeHandler = (mediaType: MediaType) => (c: Context<BaseEnv & NetworkMiddlewareEnv>) =>
+  forwardSubscribe(c.req.raw, c.env.MEDIA_NOTIFIER, {
+    network: c.var.network,
+    name: c.req.param("name"),
+    mediaType,
+  });
 
 router.get("/:name/events", subscribeHandler("avatar"));
 router.get("/:name/h/events", subscribeHandler("header"));
+
+// Firehose: every media.changed event across all names, networks, and media types.
+export const globalEventsHandler = (c: Context<BaseEnv>) =>
+  forwardSubscribe(c.req.raw, c.env.MEDIA_NOTIFIER, { scope: "global" });
 
 export default router;

--- a/src/routes/header.ts
+++ b/src/routes/header.ts
@@ -1,6 +1,6 @@
 import { vValidator } from "@hono/valibot-validator";
 import * as v from "valibot";
-import { createApp } from "@/utils/hono";
+import { createApp, getExecutionCtx } from "@/utils/hono";
 import { clientMiddleware, NetworkMiddlewareEnv } from "@/utils/chains";
 import { Address, isAddress, sha256 } from "viem";
 import { Hex } from "viem";
@@ -9,6 +9,7 @@ import { getVerifiedAddress } from "@/utils/eth";
 import { getOwnerAndAvailable } from "@/utils/owner";
 import { dataURLToBytes, R2GetOrHead } from "@/utils/data";
 import { findAndPromoteUnregisteredMedia, MEDIA_BUCKET_KEY } from "@/utils/media";
+import { notifyMediaChanged } from "@/utils/notify";
 import { isSubname, isParentOwner } from "@/utils/subname";
 
 const router = createApp<NetworkMiddlewareEnv>();
@@ -60,6 +61,7 @@ router.get("/:name/h", clientMiddleware, async (c) => {
     name,
     client,
     mediaType: "header",
+    executionCtx: getExecutionCtx(c),
   });
 
   if (unregisteredHeader) {
@@ -139,6 +141,18 @@ router.put("/:name/h", clientMiddleware, vValidator("json", uploadSchema), async
   });
 
   if (uploaded.key === key) {
+    getExecutionCtx(c).waitUntil(notifyMediaChanged(c.env, {
+      type: "media.changed",
+      mediaType: "header",
+      network,
+      name,
+      hash,
+      size: bytes.byteLength,
+      key,
+      address: verifiedAddress,
+      source: "upload",
+      timestamp: Date.now(),
+    }));
     return c.json({ message: "uploaded" }, 200);
   }
   else {

--- a/src/routes/header.ts
+++ b/src/routes/header.ts
@@ -138,6 +138,7 @@ router.put("/:name/h", clientMiddleware, vValidator("json", uploadSchema), async
 
   const uploaded = await bucket.put(key, bytes, {
     httpMetadata: { contentType: "image/jpeg" },
+    sha256: hash.slice(2),
   });
 
   if (uploaded.key === key) {

--- a/src/routes/header.ts
+++ b/src/routes/header.ts
@@ -1,6 +1,6 @@
 import { vValidator } from "@hono/valibot-validator";
 import * as v from "valibot";
-import { createApp, getExecutionCtx } from "@/utils/hono";
+import { createApp, waitUntil } from "@/utils/hono";
 import { clientMiddleware, NetworkMiddlewareEnv } from "@/utils/chains";
 import { Address, isAddress, sha256 } from "viem";
 import { Hex } from "viem";
@@ -61,7 +61,7 @@ router.get("/:name/h", clientMiddleware, async (c) => {
     name,
     client,
     mediaType: "header",
-    executionCtx: getExecutionCtx(c),
+    waitUntil: p => waitUntil(c, p),
   });
 
   if (unregisteredHeader) {
@@ -142,7 +142,7 @@ router.put("/:name/h", clientMiddleware, vValidator("json", uploadSchema), async
   });
 
   if (uploaded.key === key) {
-    getExecutionCtx(c).waitUntil(notifyMediaChanged(c.env, {
+    waitUntil(c, notifyMediaChanged(c.env, {
       type: "media.changed",
       mediaType: "header",
       network,

--- a/src/utils/hono.ts
+++ b/src/utils/hono.ts
@@ -8,23 +8,12 @@ export type BaseEnv = {
 
 export const createApp = <E extends HonoEnv>() => new Hono<BaseEnv & E>();
 
-// `c.executionCtx` throws when there is no Cloudflare ExecutionContext
-// (e.g. tests run via `app.request`). Returns a no-op stub that swallows
-// the rejection of any promise it's given so callers can use a uniform
-// `.waitUntil(...)` interface.
-type WaitUntilCtx = { waitUntil(promise: Promise<unknown>): void };
-
-const NULL_CTX: WaitUntilCtx = {
-  waitUntil(promise) {
-    void promise.catch(() => { /* swallow — no live request to surface to */ });
-  },
-};
-
-export const getExecutionCtx = (c: Context): WaitUntilCtx => {
+// `c.executionCtx` throws when there's no live request, e.g. app.request in tests.
+export const waitUntil = (c: Context, promise: Promise<unknown>): void => {
   try {
-    return c.executionCtx;
+    c.executionCtx.waitUntil(promise);
   }
   catch {
-    return NULL_CTX;
+    void promise.catch(() => {});
   }
 };

--- a/src/utils/hono.ts
+++ b/src/utils/hono.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono/tiny";
+import type { Context } from "hono";
 import type { Env as HonoEnv } from "hono/types";
 
 export type BaseEnv = {
@@ -6,3 +7,24 @@ export type BaseEnv = {
 };
 
 export const createApp = <E extends HonoEnv>() => new Hono<BaseEnv & E>();
+
+// `c.executionCtx` throws when there is no Cloudflare ExecutionContext
+// (e.g. tests run via `app.request`). Returns a no-op stub that swallows
+// the rejection of any promise it's given so callers can use a uniform
+// `.waitUntil(...)` interface.
+type WaitUntilCtx = { waitUntil(promise: Promise<unknown>): void };
+
+const NULL_CTX: WaitUntilCtx = {
+  waitUntil(promise) {
+    void promise.catch(() => { /* swallow — no live request to surface to */ });
+  },
+};
+
+export const getExecutionCtx = (c: Context): WaitUntilCtx => {
+  try {
+    return c.executionCtx;
+  }
+  catch {
+    return NULL_CTX;
+  }
+};

--- a/src/utils/hono.ts
+++ b/src/utils/hono.ts
@@ -14,6 +14,8 @@ export const waitUntil = (c: Context, promise: Promise<unknown>): void => {
     c.executionCtx.waitUntil(promise);
   }
   catch {
-    void promise.catch(() => {});
+    // No execution context to hand the work to. Run it detached, but surface
+    // failures rather than swallowing them.
+    void promise.catch(err => console.error("waitUntil fallback task failed", err));
   }
 };

--- a/src/utils/media.ts
+++ b/src/utils/media.ts
@@ -1,4 +1,4 @@
-import { type Address, type Hex, toHex } from "viem";
+import { type Address, type Hex, sha256, toHex } from "viem";
 import { EnsPublicClient, Network } from "./chains";
 import { getOwnerAndAvailable } from "./owner";
 import { notifyMediaChanged } from "./notify";
@@ -79,10 +79,14 @@ export const findAndPromoteUnregisteredMedia = async ({
     return;
   }
 
-  const [b1, b2] = unregisteredMediaFile.body.tee();
+  // Three branches: one for the put, one to return to the caller, one we may
+  // need to consume to compute sha256 for objects that R2 doesn't already have
+  // a hash for (uploads from before the route started passing `sha256:`).
+  const [putBranch, rest] = unregisteredMediaFile.body.tee();
+  const [hashBranch, b2] = rest.tee();
 
   const registeredKey = MEDIA_BUCKET_KEY.registered(network, name);
-  await bucket.put(registeredKey, b1, {
+  await bucket.put(registeredKey, putBranch, {
     httpMetadata: unregisteredMediaFile.httpMetadata,
   });
 
@@ -108,11 +112,19 @@ export const findAndPromoteUnregisteredMedia = async ({
     }
   }
 
-  // R2 auto-computes sha256 for objects ≤ 100MB; if absent, fall back to "0x".
+  // R2 only returns sha256 if the original PUT supplied it. New uploads do
+  // (see routes/avatar.ts and routes/header.ts); for older objects without it
+  // we hash the body via the spare tee branch.
   const sha256Buffer = unregisteredMediaFile.checksums?.sha256;
-  const hash: Hex = sha256Buffer
-    ? toHex(new Uint8Array(sha256Buffer))
-    : "0x";
+  let hash: Hex;
+  if (sha256Buffer) {
+    hash = toHex(new Uint8Array(sha256Buffer));
+    await hashBranch.cancel();
+  }
+  else {
+    const buf = await new Response(hashBranch).arrayBuffer();
+    hash = sha256(new Uint8Array(buf));
+  }
 
   const notifyPromise = notifyMediaChanged(env, {
     type: "media.changed",

--- a/src/utils/media.ts
+++ b/src/utils/media.ts
@@ -26,29 +26,8 @@ export const getMediaBucket = (env: Env, mediaType: MediaType) => {
   }
 };
 
-/**
- * Finds an unregistered media file (avatar or header) for a name and promotes it to registered status.
- *
- * This function performs the following steps:
- * 1. Checks if the ENS name has an owner and is available
- * 2. If the name is available or has no owner, returns undefined
- * 3. Looks for an unregistered media file in R2 storage
- * 4. If an unregistered media file is found:
- *    - Copies it to the registered path
- *    - Deletes all unregistered media files for this name
- *    - Returns the file and a readable stream of its body
- * 5. If no unregistered media file is found, returns undefined
- *
- * This is used to handle the case where a user uploads a media file before
- * the name is registered, and then later registers the name.
- *
- * @param env - The environment containing the R2 bucket
- * @param network - The blockchain network (mainnet, goerli, etc.)
- * @param name - The ENS name to check
- * @param client - The ENS public client to use for checking ownership
- * @param mediaType - The type of media ('avatar' or 'header')
- * @returns The file and body if an unregistered media file was found and promoted, undefined otherwise
- */
+// Promotes an unregistered upload to the registered key once the name has an
+// owner, deletes any other unregistered copies, and notifies subscribers.
 export const findAndPromoteUnregisteredMedia = async ({
   env,
   network,

--- a/src/utils/media.ts
+++ b/src/utils/media.ts
@@ -55,15 +55,14 @@ export const findAndPromoteUnregisteredMedia = async ({
   name,
   client,
   mediaType,
-  executionCtx,
+  waitUntil,
 }: {
   env: Env;
   client: EnsPublicClient;
   network: Network;
   name: string;
   mediaType: MediaType;
-  // Structural so both Hono's and the runtime's ExecutionContext satisfy it.
-  executionCtx?: { waitUntil(promise: Promise<unknown>): void };
+  waitUntil?: (promise: Promise<unknown>) => void;
 }) => {
   const { owner, available } = await getOwnerAndAvailable({ client, name });
 
@@ -115,7 +114,7 @@ export const findAndPromoteUnregisteredMedia = async ({
       cursor,
     });
 
-    const fileKeys = objects.map((o: { key: string }) => o.key);
+    const fileKeys = objects.map(o => o.key);
     if (!fileKeys.length) {
       break;
     }
@@ -150,12 +149,8 @@ export const findAndPromoteUnregisteredMedia = async ({
     source: "promotion",
     timestamp: Date.now(),
   });
-  if (executionCtx) {
-    executionCtx.waitUntil(notifyPromise);
-  }
-  else {
-    await notifyPromise;
-  }
+  if (waitUntil) waitUntil(notifyPromise);
+  else await notifyPromise;
 
   return {
     file: unregisteredMediaFile,

--- a/src/utils/media.ts
+++ b/src/utils/media.ts
@@ -1,5 +1,7 @@
+import { type Address, type Hex, toHex } from "viem";
 import { EnsPublicClient, Network } from "./chains";
 import { getOwnerAndAvailable } from "./owner";
+import { notifyMediaChanged } from "./notify";
 
 export type MediaType = "avatar" | "header";
 
@@ -53,12 +55,15 @@ export const findAndPromoteUnregisteredMedia = async ({
   name,
   client,
   mediaType,
+  executionCtx,
 }: {
   env: Env;
   client: EnsPublicClient;
   network: Network;
   name: string;
   mediaType: MediaType;
+  // Structural so both Hono's and the runtime's ExecutionContext satisfy it.
+  executionCtx?: { waitUntil(promise: Promise<unknown>): void };
 }) => {
   const { owner, available } = await getOwnerAndAvailable({ client, name });
 
@@ -76,7 +81,8 @@ export const findAndPromoteUnregisteredMedia = async ({
 
   const [b1, b2] = unregisteredMediaFile.body.tee();
 
-  await bucket.put(MEDIA_BUCKET_KEY.registered(network, name), b1, {
+  const registeredKey = MEDIA_BUCKET_KEY.registered(network, name);
+  await bucket.put(registeredKey, b1, {
     httpMetadata: unregisteredMediaFile.httpMetadata,
   });
 
@@ -100,6 +106,31 @@ export const findAndPromoteUnregisteredMedia = async ({
     else {
       break;
     }
+  }
+
+  // R2 auto-computes sha256 for objects ≤ 100MB; if absent, fall back to "0x".
+  const sha256Buffer = unregisteredMediaFile.checksums?.sha256;
+  const hash: Hex = sha256Buffer
+    ? toHex(new Uint8Array(sha256Buffer))
+    : "0x";
+
+  const notifyPromise = notifyMediaChanged(env, {
+    type: "media.changed",
+    mediaType,
+    network,
+    name,
+    hash,
+    size: unregisteredMediaFile.size,
+    key: registeredKey,
+    address: owner as Address,
+    source: "promotion",
+    timestamp: Date.now(),
+  });
+  if (executionCtx) {
+    executionCtx.waitUntil(notifyPromise);
+  }
+  else {
+    await notifyPromise;
   }
 
   return {

--- a/src/utils/media.ts
+++ b/src/utils/media.ts
@@ -79,11 +79,28 @@ export const findAndPromoteUnregisteredMedia = async ({
     return;
   }
 
-  // Three branches: one for the put, one to return to the caller, one we may
-  // need to consume to compute sha256 for objects that R2 doesn't already have
-  // a hash for (uploads from before the route started passing `sha256:`).
-  const [putBranch, rest] = unregisteredMediaFile.body.tee();
-  const [hashBranch, b2] = rest.tee();
+  // R2 only returns sha256 if the original PUT supplied it. New uploads do
+  // (see routes/avatar.ts and routes/header.ts); for older objects without it
+  // we hash the body via a spare tee branch. Only create that third branch
+  // when we actually need it — `tee()` couples branch lifetimes (cancel() on
+  // one branch only resolves once the sibling is also canceled), so an unused
+  // hash branch left dangling next to the returned body would hang.
+  const sha256Buffer = unregisteredMediaFile.checksums?.sha256;
+
+  let putBranch: ReadableStream<Uint8Array>;
+  let returnBranch: ReadableStream<Uint8Array>;
+  let hashBranch: ReadableStream<Uint8Array> | undefined;
+
+  if (sha256Buffer) {
+    [putBranch, returnBranch] = unregisteredMediaFile.body.tee();
+  }
+  else {
+    const [first, rest] = unregisteredMediaFile.body.tee();
+    const [second, third] = rest.tee();
+    putBranch = first;
+    hashBranch = second;
+    returnBranch = third;
+  }
 
   const registeredKey = MEDIA_BUCKET_KEY.registered(network, name);
   await bucket.put(registeredKey, putBranch, {
@@ -112,17 +129,12 @@ export const findAndPromoteUnregisteredMedia = async ({
     }
   }
 
-  // R2 only returns sha256 if the original PUT supplied it. New uploads do
-  // (see routes/avatar.ts and routes/header.ts); for older objects without it
-  // we hash the body via the spare tee branch.
-  const sha256Buffer = unregisteredMediaFile.checksums?.sha256;
   let hash: Hex;
   if (sha256Buffer) {
     hash = toHex(new Uint8Array(sha256Buffer));
-    await hashBranch.cancel();
   }
   else {
-    const buf = await new Response(hashBranch).arrayBuffer();
+    const buf = await new Response(hashBranch!).arrayBuffer();
     hash = sha256(new Uint8Array(buf));
   }
 
@@ -147,6 +159,6 @@ export const findAndPromoteUnregisteredMedia = async ({
 
   return {
     file: unregisteredMediaFile,
-    body: b2,
+    body: returnBranch,
   };
 };

--- a/src/utils/media.ts
+++ b/src/utils/media.ts
@@ -112,6 +112,8 @@ export const findAndPromoteUnregisteredMedia = async ({
     hash = toHex(new Uint8Array(sha256Buffer));
   }
   else {
+    // Only objects stored before uploads carried sha256 metadata reach this.
+    // Uploads are capped at 512 KB (MAX_IMAGE_SIZE), so buffering is bounded.
     const buf = await new Response(hashBranch!).arrayBuffer();
     hash = sha256(new Uint8Array(buf));
   }

--- a/src/utils/notify.ts
+++ b/src/utils/notify.ts
@@ -1,0 +1,15 @@
+import type { ChangePayload } from "@/durable-objects/media-notifier";
+
+export type { ChangePayload };
+
+export const notifyMediaChanged = async (
+  env: Env,
+  payload: ChangePayload,
+): Promise<void> => {
+  const id = env.MEDIA_NOTIFIER.idFromName("global");
+  const stub = env.MEDIA_NOTIFIER.get(id);
+  await stub.fetch("https://do/notify", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+};

--- a/src/utils/notify.ts
+++ b/src/utils/notify.ts
@@ -1,7 +1,5 @@
 import type { ChangePayload } from "@/durable-objects/media-notifier";
 
-export type { ChangePayload };
-
 export const notifyMediaChanged = async (
   env: Env,
   payload: ChangePayload,

--- a/src/utils/notify.ts
+++ b/src/utils/notify.ts
@@ -7,9 +7,5 @@ export const notifyMediaChanged = async (
   payload: ChangePayload,
 ): Promise<void> => {
   const id = env.MEDIA_NOTIFIER.idFromName("global");
-  const stub = env.MEDIA_NOTIFIER.get(id);
-  await stub.fetch("https://do/notify", {
-    method: "POST",
-    body: JSON.stringify(payload),
-  });
+  await env.MEDIA_NOTIFIER.get(id).notify(payload);
 };

--- a/test/integration/durable-objects/media-notifier.test.ts
+++ b/test/integration/durable-objects/media-notifier.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "vitest";
+import { env } from "cloudflare:test";
+import type { ChangePayload } from "@/durable-objects/media-notifier";
+import type { Address, Hex } from "viem";
+
+const subscribe = async (
+  instance: string,
+  network: string,
+  name: string,
+  mediaType: "avatar" | "header",
+) => {
+  const id = env.MEDIA_NOTIFIER.idFromName(instance);
+  const stub = env.MEDIA_NOTIFIER.get(id);
+  const url = new URL("https://do/subscribe");
+  url.searchParams.set("network", network);
+  url.searchParams.set("name", name);
+  url.searchParams.set("mediaType", mediaType);
+  const res = await stub.fetch(url, { headers: { Upgrade: "websocket" } });
+  expect(res.status).toBe(101);
+  const ws = res.webSocket;
+  if (!ws) throw new Error("DO did not return a webSocket");
+  ws.accept();
+  return ws;
+};
+
+const notify = async (instance: string, payload: ChangePayload) => {
+  const id = env.MEDIA_NOTIFIER.idFromName(instance);
+  const stub = env.MEDIA_NOTIFIER.get(id);
+  return stub.fetch("https://do/notify", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+};
+
+const nextMessage = (ws: WebSocket, timeoutMs = 1000) =>
+  new Promise<string>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`no message within ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+    ws.addEventListener("message", (event) => {
+      clearTimeout(timer);
+      resolve(event.data as string);
+    }, { once: true });
+  });
+
+const samplePayload = (overrides: Partial<ChangePayload> = {}): ChangePayload => ({
+  type: "media.changed",
+  mediaType: "avatar",
+  network: "mainnet",
+  name: "alice.eth",
+  hash: "0xabc" as Hex,
+  size: 100,
+  key: "mainnet/registered/alice.eth",
+  address: "0x0000000000000000000000000000000000000001" as Address,
+  source: "upload",
+  timestamp: 1735689600000,
+  ...overrides,
+});
+
+describe("MediaNotifier DO", () => {
+  test("sends a hello frame on connect", async () => {
+    const ws = await subscribe("hello-test", "mainnet", "test.eth", "avatar");
+    const message = await nextMessage(ws);
+    expect(JSON.parse(message)).toEqual({ type: "hello", protocol: 1 });
+  });
+
+  test("returns 426 if Upgrade header is missing", async () => {
+    const id = env.MEDIA_NOTIFIER.idFromName("upgrade-missing");
+    const stub = env.MEDIA_NOTIFIER.get(id);
+    const res = await stub.fetch("https://do/subscribe?network=mainnet&name=test.eth&mediaType=avatar");
+    expect(res.status).toBe(426);
+  });
+
+  test("returns 400 if subscription params are missing", async () => {
+    const id = env.MEDIA_NOTIFIER.idFromName("params-missing");
+    const stub = env.MEDIA_NOTIFIER.get(id);
+    const res = await stub.fetch("https://do/subscribe", {
+      headers: { Upgrade: "websocket" },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  // Note: cross-fetch WebSocket message delivery (DO -> test runner client end)
+  // is not observable in @cloudflare/vitest-pool-workers — the pair only carries
+  // messages within a single fetch invocation. We assert delivery via the
+  // DO-reported count (X-Delivered header) instead of waiting for the client
+  // socket to receive the message. End-to-end message flow is verified manually
+  // against `wrangler dev`.
+  test("notify only delivers to sockets with matching tag", async () => {
+    const instance = "tag-filter";
+    await subscribe(instance, "mainnet", "alice.eth", "avatar");
+    await subscribe(instance, "mainnet", "alice.eth", "avatar");
+    await subscribe(instance, "mainnet", "bob.eth", "avatar");
+    await subscribe(instance, "mainnet", "alice.eth", "header");
+
+    const payload = samplePayload({ name: "alice.eth", mediaType: "avatar" });
+    const notifyRes = await notify(instance, payload);
+    expect(notifyRes.status).toBe(204);
+    expect(notifyRes.headers.get("X-Delivered")).toBe("2");
+  });
+
+  test("notify with mismatched mediaType is filtered out", async () => {
+    const instance = "tag-filter-media";
+    await subscribe(instance, "mainnet", "alice.eth", "avatar");
+
+    const headerPayload = samplePayload({ name: "alice.eth", mediaType: "header" });
+    const res = await notify(instance, headerPayload);
+    expect(res.headers.get("X-Delivered")).toBe("0");
+  });
+
+  test("notify with mismatched network is filtered out", async () => {
+    const instance = "tag-filter-network";
+    await subscribe(instance, "mainnet", "alice.eth", "avatar");
+
+    const sepoliaPayload = samplePayload({ network: "sepolia", name: "alice.eth" });
+    const res = await notify(instance, sepoliaPayload);
+    expect(res.headers.get("X-Delivered")).toBe("0");
+  });
+
+  test("notify with no matching subscribers returns 204 and does not throw", async () => {
+    const res = await notify("empty", samplePayload({ name: "nobody.eth" }));
+    expect(res.status).toBe(204);
+    expect(res.headers.get("X-Delivered")).toBe("0");
+  });
+
+  test("closed sockets are removed from the subscriber set", async () => {
+    const instance = "closed-socket";
+    const wsClosed = await subscribe(instance, "mainnet", "alice.eth", "avatar");
+    await subscribe(instance, "mainnet", "alice.eth", "avatar");
+
+    wsClosed.close();
+    // Give the close a moment to propagate to the DO.
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    const res = await notify(instance, samplePayload());
+    expect(res.status).toBe(204);
+    expect(res.headers.get("X-Delivered")).toBe("1");
+  });
+
+  test("returns 404 for unknown DO paths", async () => {
+    const id = env.MEDIA_NOTIFIER.idFromName("unknown-path");
+    const stub = env.MEDIA_NOTIFIER.get(id);
+    const res = await stub.fetch("https://do/something-else");
+    expect(res.status).toBe(404);
+  });
+});

--- a/test/integration/durable-objects/media-notifier.test.ts
+++ b/test/integration/durable-objects/media-notifier.test.ts
@@ -23,13 +23,9 @@ const subscribe = async (
   return ws;
 };
 
-const notify = async (instance: string, payload: ChangePayload) => {
+const notify = (instance: string, payload: ChangePayload) => {
   const id = env.MEDIA_NOTIFIER.idFromName(instance);
-  const stub = env.MEDIA_NOTIFIER.get(id);
-  return stub.fetch("https://do/notify", {
-    method: "POST",
-    body: JSON.stringify(payload),
-  });
+  return env.MEDIA_NOTIFIER.get(id).notify(payload);
 };
 
 const nextMessage = (ws: WebSocket, timeoutMs = 1000) =>
@@ -84,9 +80,8 @@ describe("MediaNotifier DO", () => {
   // Note: cross-fetch WebSocket message delivery (DO -> test runner client end)
   // is not observable in @cloudflare/vitest-pool-workers — the pair only carries
   // messages within a single fetch invocation. We assert delivery via the
-  // DO-reported count (X-Delivered header) instead of waiting for the client
-  // socket to receive the message. End-to-end message flow is verified manually
-  // against `wrangler dev`.
+  // DO-reported count instead of waiting for the client socket to receive the
+  // message. End-to-end message flow is verified manually against `wrangler dev`.
   test("notify only delivers to sockets with matching tag", async () => {
     const instance = "tag-filter";
     await subscribe(instance, "mainnet", "alice.eth", "avatar");
@@ -94,34 +89,29 @@ describe("MediaNotifier DO", () => {
     await subscribe(instance, "mainnet", "bob.eth", "avatar");
     await subscribe(instance, "mainnet", "alice.eth", "header");
 
-    const payload = samplePayload({ name: "alice.eth", mediaType: "avatar" });
-    const notifyRes = await notify(instance, payload);
-    expect(notifyRes.status).toBe(204);
-    expect(notifyRes.headers.get("X-Delivered")).toBe("2");
+    const result = await notify(instance, samplePayload({ name: "alice.eth", mediaType: "avatar" }));
+    expect(result).toEqual({ delivered: 2 });
   });
 
   test("notify with mismatched mediaType is filtered out", async () => {
     const instance = "tag-filter-media";
     await subscribe(instance, "mainnet", "alice.eth", "avatar");
 
-    const headerPayload = samplePayload({ name: "alice.eth", mediaType: "header" });
-    const res = await notify(instance, headerPayload);
-    expect(res.headers.get("X-Delivered")).toBe("0");
+    const result = await notify(instance, samplePayload({ name: "alice.eth", mediaType: "header" }));
+    expect(result).toEqual({ delivered: 0 });
   });
 
   test("notify with mismatched network is filtered out", async () => {
     const instance = "tag-filter-network";
     await subscribe(instance, "mainnet", "alice.eth", "avatar");
 
-    const sepoliaPayload = samplePayload({ network: "sepolia", name: "alice.eth" });
-    const res = await notify(instance, sepoliaPayload);
-    expect(res.headers.get("X-Delivered")).toBe("0");
+    const result = await notify(instance, samplePayload({ network: "sepolia", name: "alice.eth" }));
+    expect(result).toEqual({ delivered: 0 });
   });
 
-  test("notify with no matching subscribers returns 204 and does not throw", async () => {
-    const res = await notify("empty", samplePayload({ name: "nobody.eth" }));
-    expect(res.status).toBe(204);
-    expect(res.headers.get("X-Delivered")).toBe("0");
+  test("notify with no matching subscribers returns delivered: 0 and does not throw", async () => {
+    const result = await notify("empty", samplePayload({ name: "nobody.eth" }));
+    expect(result).toEqual({ delivered: 0 });
   });
 
   test("closed sockets are removed from the subscriber set", async () => {
@@ -133,12 +123,11 @@ describe("MediaNotifier DO", () => {
     // Give the close a moment to propagate to the DO.
     await new Promise(resolve => setTimeout(resolve, 100));
 
-    const res = await notify(instance, samplePayload());
-    expect(res.status).toBe(204);
-    expect(res.headers.get("X-Delivered")).toBe("1");
+    const result = await notify(instance, samplePayload());
+    expect(result).toEqual({ delivered: 1 });
   });
 
-  test("returns 404 for unknown DO paths", async () => {
+  test("returns 404 for unknown DO HTTP paths", async () => {
     const id = env.MEDIA_NOTIFIER.idFromName("unknown-path");
     const stub = env.MEDIA_NOTIFIER.get(id);
     const res = await stub.fetch("https://do/something-else");

--- a/test/integration/durable-objects/media-notifier.test.ts
+++ b/test/integration/durable-objects/media-notifier.test.ts
@@ -77,6 +77,26 @@ describe("MediaNotifier DO", () => {
     expect(res.status).toBe(400);
   });
 
+  test("returns 400 if network is not in the allowlist", async () => {
+    const id = env.MEDIA_NOTIFIER.idFromName("bad-network");
+    const stub = env.MEDIA_NOTIFIER.get(id);
+    const res = await stub.fetch(
+      "https://do/subscribe?network=evil&name=alice.eth&mediaType=avatar",
+      { headers: { Upgrade: "websocket" } },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 400 if mediaType is not in the allowlist", async () => {
+    const id = env.MEDIA_NOTIFIER.idFromName("bad-mediatype");
+    const stub = env.MEDIA_NOTIFIER.get(id);
+    const res = await stub.fetch(
+      "https://do/subscribe?network=mainnet&name=alice.eth&mediaType=junk",
+      { headers: { Upgrade: "websocket" } },
+    );
+    expect(res.status).toBe(400);
+  });
+
   // Note: cross-fetch WebSocket message delivery (DO -> test runner client end)
   // is not observable in @cloudflare/vitest-pool-workers — the pair only carries
   // messages within a single fetch invocation. We assert delivery via the

--- a/test/integration/durable-objects/media-notifier.test.ts
+++ b/test/integration/durable-objects/media-notifier.test.ts
@@ -68,6 +68,16 @@ describe("MediaNotifier DO", () => {
     expect(res.status).toBe(426);
   });
 
+  test("accepts Upgrade header regardless of case (RFC 9110)", async () => {
+    const id = env.MEDIA_NOTIFIER.idFromName("upgrade-case");
+    const stub = env.MEDIA_NOTIFIER.get(id);
+    const res = await stub.fetch(
+      "https://do/subscribe?network=mainnet&name=test.eth&mediaType=avatar",
+      { headers: { Upgrade: "WebSocket" } },
+    );
+    expect(res.status).toBe(101);
+  });
+
   test("returns 400 if subscription params are missing", async () => {
     const id = env.MEDIA_NOTIFIER.idFromName("params-missing");
     const stub = env.MEDIA_NOTIFIER.get(id);

--- a/test/integration/durable-objects/media-notifier.test.ts
+++ b/test/integration/durable-objects/media-notifier.test.ts
@@ -23,6 +23,19 @@ const subscribe = async (
   return ws;
 };
 
+const subscribeGlobal = async (instance: string) => {
+  const id = env.MEDIA_NOTIFIER.idFromName(instance);
+  const stub = env.MEDIA_NOTIFIER.get(id);
+  const res = await stub.fetch("https://do/subscribe?scope=global", {
+    headers: { Upgrade: "websocket" },
+  });
+  expect(res.status).toBe(101);
+  const ws = res.webSocket;
+  if (!ws) throw new Error("DO did not return a webSocket");
+  ws.accept();
+  return ws;
+};
+
 const notify = (instance: string, payload: ChangePayload) => {
   const id = env.MEDIA_NOTIFIER.idFromName(instance);
   return env.MEDIA_NOTIFIER.get(id).notify(payload);
@@ -142,6 +155,31 @@ describe("MediaNotifier DO", () => {
   test("notify with no matching subscribers returns delivered: 0 and does not throw", async () => {
     const result = await notify("empty", samplePayload({ name: "nobody.eth" }));
     expect(result).toEqual({ delivered: 0 });
+  });
+
+  test("global subscribers receive a hello frame", async () => {
+    const ws = await subscribeGlobal("global-hello");
+    expect(JSON.parse(await nextMessage(ws))).toEqual({ type: "hello", protocol: 1 });
+  });
+
+  test("global subscribers receive every change regardless of tag", async () => {
+    const instance = "global-fanout";
+    await subscribe(instance, "mainnet", "alice.eth", "avatar");
+    await subscribeGlobal(instance);
+
+    // A change for a different name/type/network reaches only the global sub.
+    const other = await notify(
+      instance,
+      samplePayload({ network: "sepolia", name: "bob.eth", mediaType: "header" }),
+    );
+    expect(other).toEqual({ delivered: 1 });
+
+    // A change matching the specific sub reaches both it and the global sub.
+    const matching = await notify(
+      instance,
+      samplePayload({ network: "mainnet", name: "alice.eth", mediaType: "avatar" }),
+    );
+    expect(matching).toEqual({ delivered: 2 });
   });
 
   test("closed sockets are removed from the subscriber set", async () => {

--- a/test/integration/routes/avatar.test.ts
+++ b/test/integration/routes/avatar.test.ts
@@ -132,6 +132,51 @@ describe("Avatar Routes", () => {
       );
     });
 
+    test("promotes an unregistered avatar that already has sha256 metadata without hanging", async () => {
+      // Reproduces the case where the unregistered object was uploaded via the
+      // PUT route after we started passing `sha256:` to bucket.put. The
+      // promotion must NOT create + cancel a hash tee branch, otherwise
+      // ReadableStream.tee couples the cancel to the sibling and the GET
+      // response never resolves.
+      const imageBuffer = new Uint8Array([10, 20, 30, 40]);
+      const imageHash = sha256(imageBuffer);
+
+      await env.AVATAR_BUCKET.put(
+        media.MEDIA_BUCKET_KEY.unregistered("mainnet", MOCK_NAME, TEST_ACCOUNT.address),
+        imageBuffer,
+        {
+          httpMetadata: { contentType: "image/jpeg" },
+          sha256: imageHash.slice(2),
+        },
+      );
+
+      vi.mocked(owner.getOwnerAndAvailable).mockResolvedValue({
+        owner: TEST_ACCOUNT.address,
+        available: false,
+      });
+
+      // Bound the request so a hang fails the test instead of timing out the suite.
+      const res = await Promise.race([
+        app.request(`/${MOCK_NAME}`, {}, env),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("promotion request hung")), 2000),
+        ),
+      ]);
+
+      expect(res.status).toBe(200);
+      expect(new Uint8Array(await res.arrayBuffer())).toEqual(imageBuffer);
+
+      // Hash should come from R2 metadata, matching the value the upload stored.
+      expect(vi.mocked(notify.notifyMediaChanged)).toHaveBeenCalledWith(
+        env,
+        expect.objectContaining({
+          source: "promotion",
+          hash: imageHash,
+          size: imageBuffer.byteLength,
+        }),
+      );
+    });
+
     test("returns 404 when no avatar exists for the name", async () => {
       // Mock unregistered avatar doesn't exist
       vi.mocked(owner.getOwnerAndAvailable).mockResolvedValue({

--- a/test/integration/routes/avatar.test.ts
+++ b/test/integration/routes/avatar.test.ts
@@ -113,7 +113,9 @@ describe("Avatar Routes", () => {
       expect(putResult.httpMetadata?.contentType).toBe("image/jpeg");
       expect(await putResult.arrayBuffer()).toEqual(imageBuffer.buffer);
 
-      // Promotion fires a media.changed event with source: "promotion"
+      // Promotion fires a media.changed event with source: "promotion".
+      // The fixture is stored without R2 sha256 metadata, so this exercises
+      // the body-tee fallback path in findAndPromoteUnregisteredMedia.
       expect(vi.mocked(notify.notifyMediaChanged)).toHaveBeenCalledWith(
         env,
         expect.objectContaining({
@@ -124,6 +126,8 @@ describe("Avatar Routes", () => {
           name: MOCK_NAME,
           key: media.MEDIA_BUCKET_KEY.registered("mainnet", MOCK_NAME),
           address: TEST_ACCOUNT.address,
+          hash: sha256(imageBuffer),
+          size: imageBuffer.byteLength,
         }),
       );
     });
@@ -356,11 +360,12 @@ describe("Avatar Routes", () => {
         }
       `);
 
-      // Verify the file was uploaded to the registered path
+      // Verify the file was uploaded to the registered path with sha256 set
+      // so promotion later can read it back from R2 metadata
       expect(bucketSpy.put).toHaveBeenCalledWith(
         media.MEDIA_BUCKET_KEY.registered("mainnet", NORMALIZED_NAME),
         imageBuffer,
-        { httpMetadata: { contentType: "image/jpeg" } },
+        { httpMetadata: { contentType: "image/jpeg" }, sha256: imageHash.slice(2) },
       );
 
       // Verify a media.changed event was emitted to subscribers
@@ -388,7 +393,7 @@ describe("Avatar Routes", () => {
       });
 
       const dataURL = "data:image/jpeg;base64,test123123";
-      const { res, imageBuffer } = await uploadAvatar(NORMALIZED_NAME, dataURL, "mainnet");
+      const { res, imageBuffer, imageHash } = await uploadAvatar(NORMALIZED_NAME, dataURL, "mainnet");
 
       expect(res.status).toBe(200);
       expect(await res.json()).toMatchInlineSnapshot(`
@@ -401,7 +406,7 @@ describe("Avatar Routes", () => {
       expect(bucketSpy.put).toHaveBeenCalledWith(
         media.MEDIA_BUCKET_KEY.unregistered("mainnet", NORMALIZED_NAME, TEST_ACCOUNT.address),
         imageBuffer,
-        { httpMetadata: { contentType: "image/jpeg" } },
+        { httpMetadata: { contentType: "image/jpeg" }, sha256: imageHash.slice(2) },
       );
 
       // Notify uses the unregistered key for available names
@@ -565,7 +570,7 @@ describe("Avatar Routes", () => {
       });
 
       const dataURL = `data:image/jpeg;base64,${btoa(Array.from(imageBuffer).map(byte => String.fromCharCode(byte)).join(""))}`;
-      const { res } = await uploadAvatar(NORMALIZED_NAME, dataURL, network);
+      const { res, imageHash } = await uploadAvatar(NORMALIZED_NAME, dataURL, network);
 
       expect(res.status).toBe(200);
 
@@ -573,7 +578,7 @@ describe("Avatar Routes", () => {
       expect(bucketSpy.put).toHaveBeenCalledWith(
         media.MEDIA_BUCKET_KEY.registered(network, NORMALIZED_NAME),
         imageBuffer,
-        { httpMetadata: { contentType: "image/jpeg" } },
+        { httpMetadata: { contentType: "image/jpeg" }, sha256: imageHash.slice(2) },
       );
     });
 

--- a/test/integration/routes/avatar.test.ts
+++ b/test/integration/routes/avatar.test.ts
@@ -3,6 +3,7 @@ import * as media from "@/utils/media";
 import * as eth from "@/utils/eth";
 import * as owner from "@/utils/owner";
 import * as data from "@/utils/data";
+import * as notify from "@/utils/notify";
 import { ModuleMock } from "@test/setup/meta";
 import { env } from "cloudflare:test";
 import { normalize } from "viem/ens";
@@ -14,6 +15,10 @@ import { sha256 } from "viem/utils";
 vi.mock("@/utils/owner", () => ({
   getOwnerAndAvailable: vi.fn(),
 }) satisfies ModuleMock<typeof owner>);
+
+vi.mock("@/utils/notify", () => ({
+  notifyMediaChanged: vi.fn(),
+}) satisfies ModuleMock<typeof notify>);
 
 // Test constants
 const MOCK_NAME = "test.eth";
@@ -28,6 +33,9 @@ describe("Avatar Routes", () => {
   beforeEach(() => {
     // Reset all mocks
     vi.resetAllMocks();
+    // notifyMediaChanged returns a Promise; default vi.fn() returns undefined
+    // and that breaks `executionCtx.waitUntil(...)`.
+    vi.mocked(notify.notifyMediaChanged).mockResolvedValue(undefined);
   });
 
   const bucketSpy = {
@@ -89,19 +97,35 @@ describe("Avatar Routes", () => {
       );
 
       // Verify the function was called with correct params
-      expect(findAndPromoteUnregisteredMediaSpy).toHaveBeenCalledWith({
-        env,
-        network: "mainnet",
-        name: MOCK_NAME,
-        client: expect.anything(),
-        mediaType: "avatar",
-      });
+      expect(findAndPromoteUnregisteredMediaSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          env,
+          network: "mainnet",
+          name: MOCK_NAME,
+          client: expect.anything(),
+          mediaType: "avatar",
+        }),
+      );
 
       const putResult = await env.AVATAR_BUCKET.get(media.MEDIA_BUCKET_KEY.registered("mainnet", MOCK_NAME));
 
       assert(putResult);
       expect(putResult.httpMetadata?.contentType).toBe("image/jpeg");
       expect(await putResult.arrayBuffer()).toEqual(imageBuffer.buffer);
+
+      // Promotion fires a media.changed event with source: "promotion"
+      expect(vi.mocked(notify.notifyMediaChanged)).toHaveBeenCalledWith(
+        env,
+        expect.objectContaining({
+          type: "media.changed",
+          mediaType: "avatar",
+          source: "promotion",
+          network: "mainnet",
+          name: MOCK_NAME,
+          key: media.MEDIA_BUCKET_KEY.registered("mainnet", MOCK_NAME),
+          address: TEST_ACCOUNT.address,
+        }),
+      );
     });
 
     test("returns 404 when no avatar exists for the name", async () => {
@@ -323,7 +347,7 @@ describe("Avatar Routes", () => {
       });
 
       const dataURL = "data:image/jpeg;base64,test123123";
-      const { res, imageBuffer } = await uploadAvatar(NORMALIZED_NAME, dataURL, "mainnet");
+      const { res, imageBuffer, imageHash } = await uploadAvatar(NORMALIZED_NAME, dataURL, "mainnet");
 
       expect(res.status).toBe(200);
       expect(await res.json()).toMatchInlineSnapshot(`
@@ -337,6 +361,22 @@ describe("Avatar Routes", () => {
         media.MEDIA_BUCKET_KEY.registered("mainnet", NORMALIZED_NAME),
         imageBuffer,
         { httpMetadata: { contentType: "image/jpeg" } },
+      );
+
+      // Verify a media.changed event was emitted to subscribers
+      expect(vi.mocked(notify.notifyMediaChanged)).toHaveBeenCalledWith(
+        env,
+        expect.objectContaining({
+          type: "media.changed",
+          mediaType: "avatar",
+          source: "upload",
+          network: "mainnet",
+          name: NORMALIZED_NAME,
+          hash: imageHash,
+          size: imageBuffer.byteLength,
+          key: media.MEDIA_BUCKET_KEY.registered("mainnet", NORMALIZED_NAME),
+          address: TEST_ACCOUNT.address,
+        }),
       );
     });
 
@@ -362,6 +402,16 @@ describe("Avatar Routes", () => {
         media.MEDIA_BUCKET_KEY.unregistered("mainnet", NORMALIZED_NAME, TEST_ACCOUNT.address),
         imageBuffer,
         { httpMetadata: { contentType: "image/jpeg" } },
+      );
+
+      // Notify uses the unregistered key for available names
+      expect(vi.mocked(notify.notifyMediaChanged)).toHaveBeenCalledWith(
+        env,
+        expect.objectContaining({
+          mediaType: "avatar",
+          source: "upload",
+          key: media.MEDIA_BUCKET_KEY.unregistered("mainnet", NORMALIZED_NAME, TEST_ACCOUNT.address),
+        }),
       );
     });
 
@@ -391,8 +441,9 @@ describe("Avatar Routes", () => {
       expect(res.status).toBe(400);
       expect(await res.text()).toBe("Invalid signature");
 
-      // Verify no upload was attempted
+      // Verify no upload was attempted and no event was emitted
       expect(bucketSpy.put).not.toHaveBeenCalled();
+      expect(vi.mocked(notify.notifyMediaChanged)).not.toHaveBeenCalled();
     });
 
     test("returns 403 when the signature has expired", async () => {
@@ -496,6 +547,7 @@ describe("Avatar Routes", () => {
 
       expect(res.status).toBe(500);
       expect(await res.text()).toBe(`${NORMALIZED_NAME} not uploaded`);
+      expect(vi.mocked(notify.notifyMediaChanged)).not.toHaveBeenCalled();
     });
 
     test.each(MOCK_NETWORKS)("works with network %s", async (network) => {

--- a/test/integration/routes/events.test.ts
+++ b/test/integration/routes/events.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest";
+import { env } from "cloudflare:test";
+import app from "@/index";
+
+describe("Events routes", () => {
+  // 426 (not 404) proves the request reached the events handler. If the static
+  // /events route ever lost precedence to the /:name wildcard, this would fall
+  // through to the avatar read and fail.
+  test("GET /events without an Upgrade header returns 426", async () => {
+    const res = await app.request("/events", {}, env);
+    expect(res.status).toBe(426);
+    expect(await res.text()).toBe("expected websocket");
+  });
+
+  test("GET /:name/events without an Upgrade header returns 426", async () => {
+    const res = await app.request("/test.eth/events", {}, env);
+    expect(res.status).toBe(426);
+  });
+
+  test("GET /:name/h/events without an Upgrade header returns 426", async () => {
+    const res = await app.request("/test.eth/h/events", {}, env);
+    expect(res.status).toBe(426);
+  });
+});

--- a/test/integration/routes/header.test.ts
+++ b/test/integration/routes/header.test.ts
@@ -113,7 +113,9 @@ describe("Header Routes", () => {
       expect(putResult.httpMetadata?.contentType).toBe("image/jpeg");
       expect(await putResult.arrayBuffer()).toEqual(imageBuffer.buffer);
 
-      // Promotion fires a media.changed event with source: "promotion"
+      // Promotion fires a media.changed event with source: "promotion".
+      // The fixture is stored without R2 sha256 metadata, so this exercises
+      // the body-tee fallback path in findAndPromoteUnregisteredMedia.
       expect(vi.mocked(notify.notifyMediaChanged)).toHaveBeenCalledWith(
         env,
         expect.objectContaining({
@@ -124,6 +126,8 @@ describe("Header Routes", () => {
           name: MOCK_NAME,
           key: media.MEDIA_BUCKET_KEY.registered("mainnet", MOCK_NAME),
           address: TEST_ACCOUNT.address,
+          hash: sha256(imageBuffer),
+          size: imageBuffer.byteLength,
         }),
       );
     });
@@ -352,11 +356,12 @@ describe("Header Routes", () => {
         }
       `);
 
-      // Verify the file was uploaded to the registered path
+      // Verify the file was uploaded to the registered path with sha256 set
+      // so promotion later can read it back from R2 metadata
       expect(bucketSpy.put).toHaveBeenCalledWith(
         media.MEDIA_BUCKET_KEY.registered("mainnet", NORMALIZED_NAME),
         imageBuffer,
-        { httpMetadata: { contentType: "image/jpeg" } },
+        { httpMetadata: { contentType: "image/jpeg" }, sha256: imageHash.slice(2) },
       );
 
       // Verify a media.changed event was emitted to subscribers
@@ -384,7 +389,7 @@ describe("Header Routes", () => {
       });
 
       const dataURL = "data:image/jpeg;base64,test123123";
-      const { res, imageBuffer } = await uploadHeader(NORMALIZED_NAME, dataURL, "mainnet");
+      const { res, imageBuffer, imageHash } = await uploadHeader(NORMALIZED_NAME, dataURL, "mainnet");
 
       expect(res.status).toBe(200);
       expect(await res.json()).toMatchInlineSnapshot(`
@@ -397,7 +402,7 @@ describe("Header Routes", () => {
       expect(bucketSpy.put).toHaveBeenCalledWith(
         media.MEDIA_BUCKET_KEY.unregistered("mainnet", NORMALIZED_NAME, TEST_ACCOUNT.address),
         imageBuffer,
-        { httpMetadata: { contentType: "image/jpeg" } },
+        { httpMetadata: { contentType: "image/jpeg" }, sha256: imageHash.slice(2) },
       );
 
       // Notify uses the unregistered key for available names
@@ -561,7 +566,7 @@ describe("Header Routes", () => {
       });
 
       const dataURL = `data:image/jpeg;base64,${btoa(Array.from(imageBuffer).map(byte => String.fromCharCode(byte)).join(""))}`;
-      const { res } = await uploadHeader(NORMALIZED_NAME, dataURL, network);
+      const { res, imageHash } = await uploadHeader(NORMALIZED_NAME, dataURL, network);
 
       expect(res.status).toBe(200);
 
@@ -569,7 +574,7 @@ describe("Header Routes", () => {
       expect(bucketSpy.put).toHaveBeenCalledWith(
         media.MEDIA_BUCKET_KEY.registered(network, NORMALIZED_NAME),
         imageBuffer,
-        { httpMetadata: { contentType: "image/jpeg" } },
+        { httpMetadata: { contentType: "image/jpeg" }, sha256: imageHash.slice(2) },
       );
     });
 

--- a/test/integration/routes/header.test.ts
+++ b/test/integration/routes/header.test.ts
@@ -3,6 +3,7 @@ import * as media from "@/utils/media";
 import * as eth from "@/utils/eth";
 import * as owner from "@/utils/owner";
 import * as data from "@/utils/data";
+import * as notify from "@/utils/notify";
 import { ModuleMock } from "@test/setup/meta";
 import { env } from "cloudflare:test";
 import { normalize } from "viem/ens";
@@ -14,6 +15,10 @@ import { sha256 } from "viem/utils";
 vi.mock("@/utils/owner", () => ({
   getOwnerAndAvailable: vi.fn(),
 }) satisfies ModuleMock<typeof owner>);
+
+vi.mock("@/utils/notify", () => ({
+  notifyMediaChanged: vi.fn(),
+}) satisfies ModuleMock<typeof notify>);
 
 // Test constants
 const MOCK_NAME = "test.eth";
@@ -28,6 +33,9 @@ describe("Header Routes", () => {
   beforeEach(() => {
     // Reset all mocks
     vi.resetAllMocks();
+    // notifyMediaChanged returns a Promise; default vi.fn() returns undefined
+    // and that breaks `executionCtx.waitUntil(...)`.
+    vi.mocked(notify.notifyMediaChanged).mockResolvedValue(undefined);
   });
 
   const bucketSpy = {
@@ -89,19 +97,35 @@ describe("Header Routes", () => {
       );
 
       // Verify the function was called with correct params
-      expect(findAndPromoteUnregisteredMediaSpy).toHaveBeenCalledWith({
-        env,
-        network: "mainnet",
-        name: MOCK_NAME,
-        client: expect.anything(),
-        mediaType: "header",
-      });
+      expect(findAndPromoteUnregisteredMediaSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          env,
+          network: "mainnet",
+          name: MOCK_NAME,
+          client: expect.anything(),
+          mediaType: "header",
+        }),
+      );
 
       const putResult = await env.HEADER_BUCKET.get(media.MEDIA_BUCKET_KEY.registered("mainnet", MOCK_NAME));
 
       assert(putResult);
       expect(putResult.httpMetadata?.contentType).toBe("image/jpeg");
       expect(await putResult.arrayBuffer()).toEqual(imageBuffer.buffer);
+
+      // Promotion fires a media.changed event with source: "promotion"
+      expect(vi.mocked(notify.notifyMediaChanged)).toHaveBeenCalledWith(
+        env,
+        expect.objectContaining({
+          type: "media.changed",
+          mediaType: "header",
+          source: "promotion",
+          network: "mainnet",
+          name: MOCK_NAME,
+          key: media.MEDIA_BUCKET_KEY.registered("mainnet", MOCK_NAME),
+          address: TEST_ACCOUNT.address,
+        }),
+      );
     });
 
     test("returns 404 when no header exists for the name", async () => {
@@ -319,7 +343,7 @@ describe("Header Routes", () => {
       });
 
       const dataURL = "data:image/jpeg;base64,test123123";
-      const { res, imageBuffer } = await uploadHeader(NORMALIZED_NAME, dataURL, "mainnet");
+      const { res, imageBuffer, imageHash } = await uploadHeader(NORMALIZED_NAME, dataURL, "mainnet");
 
       expect(res.status).toBe(200);
       expect(await res.json()).toMatchInlineSnapshot(`
@@ -333,6 +357,22 @@ describe("Header Routes", () => {
         media.MEDIA_BUCKET_KEY.registered("mainnet", NORMALIZED_NAME),
         imageBuffer,
         { httpMetadata: { contentType: "image/jpeg" } },
+      );
+
+      // Verify a media.changed event was emitted to subscribers
+      expect(vi.mocked(notify.notifyMediaChanged)).toHaveBeenCalledWith(
+        env,
+        expect.objectContaining({
+          type: "media.changed",
+          mediaType: "header",
+          source: "upload",
+          network: "mainnet",
+          name: NORMALIZED_NAME,
+          hash: imageHash,
+          size: imageBuffer.byteLength,
+          key: media.MEDIA_BUCKET_KEY.registered("mainnet", NORMALIZED_NAME),
+          address: TEST_ACCOUNT.address,
+        }),
       );
     });
 
@@ -358,6 +398,16 @@ describe("Header Routes", () => {
         media.MEDIA_BUCKET_KEY.unregistered("mainnet", NORMALIZED_NAME, TEST_ACCOUNT.address),
         imageBuffer,
         { httpMetadata: { contentType: "image/jpeg" } },
+      );
+
+      // Notify uses the unregistered key for available names
+      expect(vi.mocked(notify.notifyMediaChanged)).toHaveBeenCalledWith(
+        env,
+        expect.objectContaining({
+          mediaType: "header",
+          source: "upload",
+          key: media.MEDIA_BUCKET_KEY.unregistered("mainnet", NORMALIZED_NAME, TEST_ACCOUNT.address),
+        }),
       );
     });
 
@@ -387,8 +437,9 @@ describe("Header Routes", () => {
       expect(res.status).toBe(400);
       expect(await res.text()).toBe("Invalid signature");
 
-      // Verify no upload was attempted
+      // Verify no upload was attempted and no event was emitted
       expect(bucketSpy.put).not.toHaveBeenCalled();
+      expect(vi.mocked(notify.notifyMediaChanged)).not.toHaveBeenCalled();
     });
 
     test("returns 403 when the signature has expired", async () => {
@@ -492,6 +543,7 @@ describe("Header Routes", () => {
 
       expect(res.status).toBe(500);
       expect(await res.text()).toBe(`${NORMALIZED_NAME} not uploaded`);
+      expect(vi.mocked(notify.notifyMediaChanged)).not.toHaveBeenCalled();
     });
 
     test.each(MOCK_NETWORKS)("works with network %s", async (network) => {

--- a/vitest.config.do.ts
+++ b/vitest.config.do.ts
@@ -2,14 +2,11 @@ import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
 
 export default defineWorkersConfig({
   test: {
-    exclude: [
-      "**/node_modules/**",
-      "**/dist/**",
-      "test/integration/durable-objects/**",
-    ],
+    include: ["test/integration/durable-objects/**/*.test.ts"],
     poolOptions: {
       workers: {
         wrangler: { configPath: "./wrangler.jsonc" },
+        isolatedStorage: false,
       },
     },
     alias: {

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -5,6 +5,7 @@ interface Env {
 	WEB3_ENDPOINT_MAP: string;
 	AVATAR_BUCKET: R2Bucket;
 	HEADER_BUCKET: R2Bucket;
+	MEDIA_NOTIFIER: DurableObjectNamespace<import("./src/durable-objects/media-notifier").MediaNotifier>;
 	LOCALHOST_ENS_REGISTRY?: string;
 	LOCALHOST_ENS_NAME_WRAPPER?: string;
 	LOCALHOST_ENS_UNIVERSAL_RESOLVER?: string;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -27,6 +27,20 @@
             "preview_bucket_name": "preview-header-storage"
         }
     ],
+    "durable_objects": {
+        "bindings": [
+            {
+                "name": "MEDIA_NOTIFIER",
+                "class_name": "MediaNotifier"
+            }
+        ]
+    },
+    "migrations": [
+        {
+            "tag": "v1",
+            "new_classes": ["MediaNotifier"]
+        }
+    ],
     "vars": {
         "ENVIRONMENT": "dev"
     },

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -48,12 +48,64 @@
         "staging": {
             "vars": {
                 "ENVIRONMENT": "staging"
-            }
+            },
+            "r2_buckets": [
+                {
+                    "binding": "AVATAR_BUCKET",
+                    "bucket_name": "avatar-storage",
+                    "preview_bucket_name": "preview-avatar-storage"
+                },
+                {
+                    "binding": "HEADER_BUCKET",
+                    "bucket_name": "header-storage",
+                    "preview_bucket_name": "preview-header-storage"
+                }
+            ],
+            "durable_objects": {
+                "bindings": [
+                    {
+                        "name": "MEDIA_NOTIFIER",
+                        "class_name": "MediaNotifier"
+                    }
+                ]
+            },
+            "migrations": [
+                {
+                    "tag": "v1",
+                    "new_classes": ["MediaNotifier"]
+                }
+            ]
         },
         "production": {
             "vars": {
                 "ENVIRONMENT": "production"
-            }
+            },
+            "r2_buckets": [
+                {
+                    "binding": "AVATAR_BUCKET",
+                    "bucket_name": "avatar-storage",
+                    "preview_bucket_name": "preview-avatar-storage"
+                },
+                {
+                    "binding": "HEADER_BUCKET",
+                    "bucket_name": "header-storage",
+                    "preview_bucket_name": "preview-header-storage"
+                }
+            ],
+            "durable_objects": {
+                "bindings": [
+                    {
+                        "name": "MEDIA_NOTIFIER",
+                        "class_name": "MediaNotifier"
+                    }
+                ]
+            },
+            "migrations": [
+                {
+                    "tag": "v1",
+                    "new_classes": ["MediaNotifier"]
+                }
+            ]
         }
     }
     // "d1_databases": [


### PR DESCRIPTION
## What this adds

Realtime notifications for avatar and header changes. Clients open a WebSocket and get a `media.changed` JSON frame the moment an upload completes, or when an unregistered upload gets promoted to its registered key.

Two ways to subscribe:

- Per name: `/:network/:name/events` (avatar) or `/:network/:name/h/events` (header). You get changes for that one name and media type.
- Firehose: `/events` gives every change across all names, all networks, and both media types. Handy for indexers or a global activity feed. The payload carries `network`, `name`, and `mediaType`, so clients filter the stream themselves.

The plumbing:

- One global Durable Object (`MediaNotifier`) holds subscriber sockets in an in-memory `Map<tag, Set<WebSocket>>` where the tag is `${network}:${name}:${mediaType}`. Firehose subscribers live under a `*` sentinel tag.
- The worker forwards WS upgrades to the DO over HTTP (the only way to start a WS) and calls `notify(payload)` on the DO via its typed RPC stub for everything else. No internal HTTP round trip, no public `/notify` endpoint.
- `notify` delivers to both the matching name tag and the `*` tag, so a firehose subscriber sees changes a per-name subscriber would miss. A socket only ever lives in one bucket, so nothing is sent twice.
- Both PUT routes and the unregistered to registered promotion path in `findAndPromoteUnregisteredMedia` fire events through `waitUntil(c, promise)` so the HTTP response stays fast and a notify failure cannot break an upload.

Event payload (`ChangePayload` from `src/durable-objects/media-notifier.ts`):

```jsonc
{
  "type": "media.changed",
  "mediaType": "avatar",            // "avatar" | "header"
  "network": "mainnet",
  "name": "vitalik.eth",
  "hash": "0x...",                   // sha256(bytes), Hex
  "size": 12345,
  "key": "mainnet/registered/vitalik.eth",
  "address": "0x...",                // uploader on upload, owner on promotion
  "source": "upload",                // "upload" | "promotion"
  "timestamp": 1735689600000
}
```

A `{ "type": "hello", "protocol": 1 }` frame is sent on connect.

## Topology

One global DO. Per-name DOs would scale further but multiply operational surface, and tag-based fan-out inside one DO is plenty for the subscriber counts this worker realistically handles. Swapping to per-name later is a one-line change in `notify.ts` and the events router (the URL routing is path-based already). The firehose is O(global subscribers) per event on the single DO, which is the cost of the single-DO choice.

The `:` separator in the tag is safe because ENSIP-15 normalization rejects it (verified against `viem/ens.normalize`), and the upload routes already gate on `name === normalize(name)`. The `*` firehose tag can't collide either, since every real tag carries a fixed-set network prefix. The DO also allowlist-checks `network` and `mediaType` against their unions on subscribe, so a stub caller can't push junk into the subscriber map.

## For maintainers to weigh in on

**WebSocket subscriptions skip the production CORS allowlist.** The top-level cors middleware is bypassed for `Upgrade: websocket` requests because Hono's cors clones the route response to inject headers, and that fails on a 101 status. Browsers don't enforce CORS on WS handshakes anyway (they only send `Origin`), so any site can open a subscription and read `media.changed` events for any name (or the whole firehose).

This is read-only data that's also reachable via the existing public GET routes, so I don't think the security impact is meaningful. But if you want the same origin policy that gates the GETs to apply here too, the right fix is to validate `Origin` against `PROD_ALLOWED_ORIGIN_SUFFIXES` inside the events handler (or close the socket from inside the DO's subscribe handler when the origin doesn't match). Happy to add that in this PR or a follow up. Let me know which way you want to go.

## Manual verification

Start the local worker:

```bash
pnpm dev   # wrangler dev on :8787
```

Per-name subscribe (expect 101 + the hello frame):

```bash
curl -i \
  -H "Upgrade: websocket" -H "Connection: Upgrade" \
  -H "Sec-WebSocket-Version: 13" -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
  http://localhost:8787/test.eth/events
# HTTP/1.1 101 Switching Protocols
# {"type":"hello","protocol":1}
```

Firehose subscribe (same handshake, no name):

```bash
curl -i \
  -H "Upgrade: websocket" -H "Connection: Upgrade" \
  -H "Sec-WebSocket-Version: 13" -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
  http://localhost:8787/events
# HTTP/1.1 101 Switching Protocols
# {"type":"hello","protocol":1}
```

Then in a second terminal, PUT a valid avatar (using `test/setup/helpers.ts:createTestUploadData`) and you should see a `media.changed` JSON frame land on both the per-name and the firehose sockets within ~100ms. Same flow against `/test.eth/h/events` for the header.

Promotion: upload an avatar to a name while it's available, wait for it to register, then GET `/test.eth` once. A `source: "promotion"` event fires on any open subscription that matches (and on the firehose).